### PR TITLE
Add support for browser and node outputs from a package

### DIFF
--- a/build-settings/babel.config.js
+++ b/build-settings/babel.config.js
@@ -1,23 +1,10 @@
 /* eslint-disable import/no-commonjs */
+const createBabelPresets = require("./create-babel-presets.js");
+
+// This config is used for Jest testing here in this repository, only.
 module.exports = {
-    presets: ["@babel/preset-flow", "@babel/preset-env"],
-    env: {
-        test: {
-            presets: [
-                "@babel/preset-flow",
-                [
-                    "@babel/preset-env",
-                    {
-                        targets: {
-                            // Our currently minimum support is node 12
-                            // TODO: We'll want to change this based on the
-                            // package being created since some will want
-                            // to support node and browser, or just node.
-                            node: 12,
-                        },
-                    },
-                ],
-            ],
-        },
-    },
+    presets: createBabelPresets({
+        platform: "node",
+        format: "cjs",
+    }),
 };

--- a/build-settings/create-babel-presets.js
+++ b/build-settings/create-babel-presets.js
@@ -1,0 +1,19 @@
+/* eslint-disable import/no-commonjs */
+module.exports = function createBabelPresets({platform, format}) {
+    const targets = {};
+    if (platform === "node") {
+        targets.node = true;
+    }
+    if (format === "esm") {
+        targets.esmodules = true;
+    }
+    return [
+        "@babel/preset-flow",
+        [
+            "@babel/preset-env",
+            {
+                targets,
+            },
+        ],
+    ];
+};

--- a/build-settings/rollup.config.js
+++ b/build-settings/rollup.config.js
@@ -1,33 +1,47 @@
 /* eslint-disable import/no-commonjs */
 import fs from "fs";
+import path from "path";
 import autoExternal from "rollup-plugin-auto-external";
 import {babel} from "@rollup/plugin-babel";
 import {terser} from "rollup-plugin-terser";
 import copy from "rollup-plugin-copy";
+import resolve from "@rollup/plugin-node-resolve";
 
-const {presets, plugins} = require("./babel.config.js");
+const createBabelPresets = require("./create-babel-presets.js");
 
 /**
- * Creates the rollup config shared by all our output formats.
+ * Make path to a package relative path.
  */
-const createSharedConfig = (pkgName) => ({
-    input: `packages/${pkgName}/src/index.js`,
+const makePackageBasedPath = (pkgName, pkgRelPath) =>
+    path.normalize(path.join("packages", pkgName, pkgRelPath));
+
+/**
+ * Generate the rollup output configuration for a given
+ */
+const createOutputConfig = (pkgName, format, targetFile) => ({
+    file: makePackageBasedPath(pkgName, targetFile),
+    sourcemap: true,
+    format,
+});
+
+const createConfig = ({name, format, platform, file}) => ({
+    output: createOutputConfig(name, format, file),
+    input: makePackageBasedPath(name, "./src/index.js"),
     plugins: [
         babel({
             babelHelpers: "bundled",
-            presets,
-            plugins,
+            presets: createBabelPresets({platform, format}),
             exclude: "node_modules/**",
         }),
+        resolve({
+            browser: platform === "browser",
+        }),
         autoExternal({
-            packagePath: `packages/${pkgName}/package.json`,
+            packagePath: makePackageBasedPath(name, "./package.json"),
         }),
         terser(),
 
         // This generates the flow import file.
-        // The copyOnce ensures that we copy just once for a specific target
-        // file, even if we have multiple copy plugin configs for that file,
-        // so it's ok that we duplicate this step in our two outputs.
         copy({
             copyOnce: true,
             verbose: true,
@@ -37,7 +51,7 @@ const createSharedConfig = (pkgName) => ({
                     // with ./
                     src: "build-settings/index.flow.js.template",
                     // dest path is relative to src path.
-                    dest: `packages/${pkgName}/dist`,
+                    dest: makePackageBasedPath(name, "./dist"),
                     rename: "index.flow.js",
                 },
             ],
@@ -45,41 +59,50 @@ const createSharedConfig = (pkgName) => ({
     ],
 });
 
-/**
- * For a given package, generate the outputs we want.
- * - CommonJS
- * - ES6
- *
- * https://redfin.engineering/node-modules-at-war-why-commonjs-and-es-modules-cant-get-along-9617135eeca1
- * Per the above blog, we could possibly do better for our consumers by making
- * the ES6 output wrap the CJS output so folks can't accidentally have code
- * including two full copies of the same code somehow, but then that wouldn't
- * have the benefits of ES6 like tree shaking. In reality, the CJS output is
- * likely only used by Jest anyway. We could force consumers to use Babel around
- * their imports so that Jest mocking is supported, but that feels mean and
- * messy.
- */
-const createConfig = (pkgName) => {
-    const sharedConfig = createSharedConfig(pkgName);
+// For each package in our packages folder, generate the outputs we want.
+// To determine what those outputs are, we read the package.json file for
+// each package. If the package has a `browser` field, then we generate
+// browser and node assets. If not, we just generate the node assets.
+// Note that we also get the output paths from the package.json.
+const getPackageInfo = (pkgName) => {
+    const pkgJsonPath = makePackageBasedPath(pkgName, "./package.json");
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath));
+
+    // Now we have the package.json, we need to look at the main, module, and
+    // browser fields and values.
+    const {main: cjsNode, module: esmNode, browser} = pkgJson;
+    const cjsBrowser = browser == null ? undefined : browser[cjsNode];
+    const esmBrowser = browser == null ? undefined : browser[esmNode];
+
     return [
         {
-            output: {
-                file: `packages/${pkgName}/dist/index.js`,
-                sourcemap: true,
-                format: "cjs",
-            },
-            ...sharedConfig,
+            name: pkgName,
+            format: "esm",
+            platform: "node",
+            file: esmNode,
         },
         {
-            output: {
-                file: `packages/${pkgName}/dist/es/index.js`,
-                sourcemap: true,
-                format: "esm",
-            },
-            ...sharedConfig,
+            name: pkgName,
+            format: "esm",
+            platform: "browser",
+            file: esmBrowser,
         },
-    ];
+        {
+            name: pkgName,
+            format: "cjs",
+            platform: "node",
+            file: cjsNode,
+        },
+        {
+            name: pkgName,
+            format: "cjs",
+            platform: "browser",
+            file: cjsBrowser,
+        },
+    ].filter((i) => !!i.file);
 };
 
-// For each package in our packages folder, generate the outputs we want.
-export default fs.readdirSync("packages").flatMap(createConfig);
+export default fs
+    .readdirSync("packages")
+    .flatMap(getPackageInfo)
+    .map(createConfig);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/preset-flow": "^7.14.5",
     "@khanacademy/eslint-config": "^0.1.0",
     "@rollup/plugin-babel": "^5.3.0",
+    "@rollup/plugin-node-resolve": "^13.0.5",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^27.2.4",
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@khanacademy/eslint-config": "^0.1.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-node-resolve": "^13.0.5",
+    "@rollup/plugin-replace": "^3.0.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^27.2.4",
     "eslint": "^7.32.0",
@@ -44,7 +45,8 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "scripts": {
-    "build": "rollup -c build-settings/rollup.config.js",
+    "build": "NODE_ENV=production rollup -c build-settings/rollup.config.js",
+    "watch": "NODE_ENV=development rollup -c build-settings/rollup.config.js --watch",
     "clean": "rm -rf packages/wonder-stuff-*/dist && rm -rf packages/wonder-stuff-*/node_modules",
     "coverage": "yarn run jest --coverage",
     "flow:ci": "flow check --max-workers 0",

--- a/packages/wonder-stuff-core/package.json
+++ b/packages/wonder-stuff-core/package.json
@@ -15,6 +15,10 @@
     "devDependencies": {
         "ws-dev-build-settings": "^0.0.2"
     },
+    "browser": {
+        "dist/es/index.js": "dist/es/index.browser.js",
+        "dist/index.js": "dist/index.browser.js"
+    },
     "author": "",
     "license": "MIT"
 }

--- a/packages/wonder-stuff-core/package.json
+++ b/packages/wonder-stuff-core/package.json
@@ -4,7 +4,7 @@
     },
     "private": true,
     "name": "@khanacademy/wonder-stuff-core",
-    "version": "1.0.0",
+    "version": "0.0.1",
     "description": "",
     "module": "dist/es/index.js",
     "main": "dist/index.js",

--- a/packages/wonder-stuff-core/src/index.js
+++ b/packages/wonder-stuff-core/src/index.js
@@ -1,3 +1,16 @@
+/* eslint-disable no-console */
 // @flow
-// eslint-disable-next-line no-console
-console.log("Hello World!");
+switch (process.env.NODE_ENV) {
+    default:
+    case "production":
+        console.log("Hello production World!");
+        break;
+
+    case "development":
+        console.log("Hello development World!");
+        break;
+
+    case "test":
+        console.log("Hello test World!");
+        break;
+}

--- a/utils/pre-publish-check.js
+++ b/utils/pre-publish-check.js
@@ -39,8 +39,31 @@ const checkPackageField = (pkgJson, field, value) => {
     }
 };
 
-const checkPackageModule = (pkgJson) =>
-    checkPackageField(pkgJson, "module", "dist/index.js");
+const checkPackageEntrypoints = (pkgJson) => {
+    checkPackageField(pkgJson, "module", "dist/es/index.js");
+    checkPackageField(pkgJson, "main", "dist/index.js");
+    if (pkgJson.browser) {
+        const expectedValue = {
+            [pkgJson.main]: "dist/index.browser.js",
+            [pkgJson.module]: "dist/es/index.browser.js",
+        };
+
+        for (const key of Object.keys(pkgJson.browser)) {
+            if (expectedValue[key] !== pkgJson.browser[key]) {
+                console.error(
+                    `ERROR: ${
+                        pkgJson.name
+                    } must have a "browser" set to \n${JSON.stringify(
+                        expectedValue,
+                        null,
+                        4,
+                    )}.`,
+                );
+                process.exit(1);
+            }
+        }
+    }
+};
 
 const checkPackageSource = (pkgJson) =>
     checkPackageField(pkgJson, "source", "src/index.js");
@@ -76,7 +99,7 @@ fg(path.join(__dirname, "..", "packages", "**", "package.json")).then(
             const pkgJson = require(path.relative(__dirname, pkgPath));
 
             checkPublishConfig(pkgJson);
-            checkPackageModule(pkgJson);
+            checkPackageEntrypoints(pkgJson);
             checkPackageSource(pkgJson);
             warnings = checkPackagePrivate(pkgJson);
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2080,6 +2080,14 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
+"@rollup/plugin-replace@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-3.0.0.tgz#3a4c9665d4e7a4ce2c360cf021232784892f3fac"
+  integrity sha512-3c7JCbMuYXM4PbPWT4+m/4Y6U60SgsnDT/cCyAyUKwFHg7pTSfsSQzIpETha3a3ig6OdOKzZz87D9ZXIK3qsDg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    magic-string "^0.25.7"
+
 "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -5986,6 +5994,13 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
 make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -7806,6 +7821,11 @@ source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2068,6 +2068,18 @@
     "@babel/helper-module-imports" "^7.10.4"
     "@rollup/pluginutils" "^3.1.0"
 
+"@rollup/plugin-node-resolve@^13.0.5":
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.5.tgz#016abe58796a4ff544d6beac7818921e3d3777fc"
+  integrity sha512-mVaw6uxtvuGx/XCI4qBQXsDZJUfyx5vp39iE0J/7Hd6wDhEbjHr6aES7Nr9yWbuE0BY+oKp6N7Bq6jX5NCGNmQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
 "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -2222,6 +2234,13 @@
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.1.tgz#e1303048d5389563e130f5bdd89d37a99acb75eb"
   integrity sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -2831,6 +2850,11 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+builtin-modules@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
+  integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
 
 builtins@^1.0.3:
   version "1.0.3"
@@ -4929,6 +4953,11 @@ is-lambda@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
   integrity sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
 
 is-negative-zero@^2.0.1:
   version "2.0.1"
@@ -7409,7 +7438,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.20.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==


### PR DESCRIPTION
## Summary:
Also:
- Add support for process.env.NODE_ENV and package watching
- Update prepublish checks to cover browser setting

Overall, this gets us setup to publish packages that support ESM and CJS
in browser and node. We can probably drop the browser CJS file if we
really wanted, but this way, it's safe - no one can accidentally include
the wrong thing.

Also includes support for differing behavior based on the value of
`process.env.NODE_ENV` during the build. Downside here of course is that
if code wanted to differentiate based on the value of `process.env.NODE_ENV`
at runtime, they will have to use a different syntax to get the value so
that it isn't replaced at build time. This is entirely possible though,
so I think that's just fine.

I believe this concludes our initial setup of the repo. Time to add code.

Issue: FEI-4002

## Test plan:
`yarn flow`
`yarn test`
`yarn build`
`yarn build --configPackages=core`
`yarn build --configPackages=poop` fails as it should
`yarn watch`
`yarn watch --configPackages=core`
`yarn watch --configPackages=poop` fails as it should
`node ./utils/pre-publish-check.js` against various edits of the core package.json to verify the checks are working.