### PR TITLE
[🔥AUDIT🔥] [fei3998.audit.1] Do not normalize message when there is no cause

### DIFF
--- a/packages/wonder-stuff-core/package.json
+++ b/packages/wonder-stuff-core/package.json
@@ -9,7 +9,7 @@
     "main": "dist/index.js",
     "source": "src/index.js",
     "scripts": {
-        "test": "echo \"Run tests from the repository root\" && exit 1"
+        "test": "bash -c 'yarn --silent --cwd \"../..\" test $PWD'"
     },
     "devDependencies": {
         "ws-dev-build-settings": "^0.0.3"

--- a/packages/wonder-stuff-core/src/__tests__/kind-error.test.js
+++ b/packages/wonder-stuff-core/src/__tests__/kind-error.test.js
@@ -188,7 +188,7 @@ describe("KindError", () => {
             expect(error.stack).toBe(normalizedErrorInfo.standardizedStack);
         });
 
-        it("should set the message to the normalized value", () => {
+        it("should not set the message to the normalized value", () => {
             // Arrange
             const normalizedErrorInfo = new ErrorInfo(
                 "NORMALIZED_NAME",
@@ -203,7 +203,7 @@ describe("KindError", () => {
             const error = new KindError("MESSAGE", Errors.Unknown);
 
             // Assert
-            expect(error.message).toBe(normalizedErrorInfo.message);
+            expect(error.message).toBe("MESSAGE");
         });
 
         describe("when cause is non-null", () => {

--- a/packages/wonder-stuff-core/src/kind-error.js
+++ b/packages/wonder-stuff-core/src/kind-error.js
@@ -166,8 +166,9 @@ export class KindError extends Error {
         delete this.stack;
 
         if (cause == null) {
-            // If there is no cause, we can just use the normalized error.
-            this.message = normalizedError.message;
+            // If there is no cause, so we just use the normalized stack.
+            // We don't use the normalized message here as we want to retain
+            // all lines of the message in this case.
             this.stack = normalizedError.standardizedStack;
         } else {
             // We want to generate a better stack trace using the source error

--- a/packages/wonder-stuff-sentry/package.json
+++ b/packages/wonder-stuff-sentry/package.json
@@ -9,7 +9,7 @@
     "main": "dist/index.js",
     "source": "src/index.js",
     "scripts": {
-        "test": "echo \"Run tests from the repository root\" && exit 1"
+        "test": "bash -c 'yarn --silent --cwd \"../..\" test $PWD'"
     },
     "dependencies": {
         "@khanacademy/wonder-stuff-core": "^0.1.0"


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We don't want to normalize the message when we don't have a cause
as that would strip any useful information that the message might have
in that circumstance.

Issue: FEI-3998

## Test plan:
`yarn test`