### PR TITLE
[fei4142.1] A few fixes based on usage

### DIFF
--- a/build-settings/rollup.config.js
+++ b/build-settings/rollup.config.js
@@ -76,10 +76,10 @@ const getPackageInfo = (pkgName) => {
     const cjsBrowser = browser == null ? undefined : browser[cjsNode];
     const esmBrowser = browser == null ? undefined : browser[esmNode];
 
-    // This generates the flow import file.
+    // This generates the flow import file and a file for intellisense to work.
     // By using the same instance of it across all output configurations
     // while using the `copyOnce` value, we ensure it only gets copied one time.
-    const flowCopy = copy({
+    const typesAndDocsCopy = copy({
         copyOnce: true,
         verbose: true,
         targets: [
@@ -91,6 +91,14 @@ const getPackageInfo = (pkgName) => {
                 dest: makePackageBasedPath(pkgName, "./dist"),
                 rename: "index.js.flow",
             },
+            {
+                // src path is relative to the package root unless started
+                // with ./
+                src: "build-settings/index.js.flow.template",
+                // dest path is relative to src path.
+                dest: makePackageBasedPath(pkgName, "./dist"),
+                rename: "index.d.ts",
+            },
         ],
     });
     return [
@@ -99,28 +107,28 @@ const getPackageInfo = (pkgName) => {
             format: "esm",
             platform: "node",
             file: esmNode,
-            plugins: [flowCopy],
+            plugins: [typesAndDocsCopy],
         },
         {
             name: pkgName,
             format: "esm",
             platform: "browser",
             file: esmBrowser,
-            plugins: [flowCopy],
+            plugins: [typesAndDocsCopy],
         },
         {
             name: pkgName,
             format: "cjs",
             platform: "node",
             file: cjsNode,
-            plugins: [flowCopy],
+            plugins: [typesAndDocsCopy],
         },
         {
             name: pkgName,
             format: "cjs",
             platform: "browser",
             file: cjsBrowser,
-            plugins: [flowCopy],
+            plugins: [typesAndDocsCopy],
         },
     ].filter((i) => !!i.file);
 };

--- a/packages/wonder-stuff-core/README.md
+++ b/packages/wonder-stuff-core/README.md
@@ -1,0 +1,4 @@
+# wonder-stuff-core
+
+This Wonder Stuff package contains the basic APIs that most other packages
+use.

--- a/packages/wonder-stuff-core/package.json
+++ b/packages/wonder-stuff-core/package.json
@@ -15,8 +15,8 @@
         "ws-dev-build-settings": "^0.0.3"
     },
     "browser": {
-        "dist/es/index.js": "dist/es/index.browser.js",
-        "dist/index.js": "dist/index.browser.js"
+        "dist/es/index.js": "./dist/es/index.browser.js",
+        "dist/index.js": "./dist/index.browser.js"
     },
     "author": "",
     "license": "MIT"

--- a/packages/wonder-stuff-core/package.json
+++ b/packages/wonder-stuff-core/package.json
@@ -4,7 +4,7 @@
     },
     "name": "@khanacademy/wonder-stuff-core",
     "version": "0.1.1",
-    "description": "",
+    "description": "Core APIs for doing useful things that most things want to do",
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.js",

--- a/packages/wonder-stuff-core/package.json
+++ b/packages/wonder-stuff-core/package.json
@@ -9,7 +9,7 @@
     "main": "dist/index.js",
     "source": "src/index.js",
     "scripts": {
-        "test": "bash -c 'yarn --silent --cwd \"../..\" test $PWD'"
+        "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },
     "devDependencies": {
         "ws-dev-build-settings": "^0.0.3"

--- a/packages/wonder-stuff-core/src/__tests__/clone.test.js
+++ b/packages/wonder-stuff-core/src/__tests__/clone.test.js
@@ -1,0 +1,93 @@
+// @flow
+import {clone} from "../clone.js";
+
+describe("#clone", () => {
+    it.each([undefined, null])(
+        "should return the value when it is %s",
+        (value) => {
+            // Arrange
+
+            // Act
+            const result = clone(value);
+
+            // Assert
+            expect(result).toBe(value);
+        },
+    );
+
+    it("should clone a simple object", () => {
+        // Arrange
+        const originalValue = {
+            string: "bar",
+            number: "42",
+            boolean: "true",
+            undefined: undefined,
+            null: null,
+        };
+
+        // Act
+        const result = clone(originalValue);
+
+        // Assert
+        expect(result).toStrictEqual(originalValue);
+        expect(result).not.toBe(originalValue);
+    });
+
+    it("should clone arrays", () => {
+        // Arrange
+        const originalValue = {
+            array: [1, 2, 3],
+        };
+
+        // Act
+        const result = clone(originalValue);
+
+        // Assert
+        expect(result).toStrictEqual(originalValue);
+        expect(result).not.toBe(originalValue);
+    });
+
+    it("should clone objects", () => {
+        // Arrange
+        const originalValue = {
+            object: {
+                a: 1,
+                b: 2,
+            },
+        };
+
+        // Act
+        const result = clone(originalValue);
+
+        // Assert
+        expect(result).toStrictEqual(originalValue);
+        expect(result).not.toBe(originalValue);
+    });
+
+    it("should clone nested objects and arrays", () => {
+        // Arrange
+        const originalValue = {
+            object: {
+                a: 1,
+                b: 2,
+                c: {
+                    d: 3,
+                    e: [
+                        4,
+                        5,
+                        {
+                            nested: "in here",
+                        },
+                    ],
+                },
+            },
+        };
+
+        // Act
+        const result = clone(originalValue);
+
+        // Assert
+        expect(result).toStrictEqual(originalValue);
+        expect(result).not.toBe(originalValue);
+    });
+});

--- a/packages/wonder-stuff-core/src/__tests__/kind-error.test.js
+++ b/packages/wonder-stuff-core/src/__tests__/kind-error.test.js
@@ -275,26 +275,6 @@ describe("KindError", () => {
                 );
             });
 
-            it("should set the stack to the combined error standardized stack", () => {
-                // Arrange
-                const cause = new Error("CAUSE_MESSAGE");
-                const combinedErrorInfo = new ErrorInfo(
-                    "COMBINED_NAME",
-                    "COMBINED_MESSAGE",
-                    ["combinedstack1", "combinedstack2"],
-                );
-                jest.spyOn(
-                    ErrorInfo,
-                    "fromConsequenceAndCause",
-                ).mockReturnValue(combinedErrorInfo);
-
-                // Act
-                const error = new KindError("MESSAGE", Errors.Unknown, {cause});
-
-                // Assert
-                expect(error.stack).toBe(combinedErrorInfo.standardizedStack);
-            });
-
             it("should set the message to the combined error info message", () => {
                 // Arrange
                 const cause = new Error("CAUSE_MESSAGE");
@@ -338,6 +318,71 @@ describe("KindError", () => {
                     		Error: CAUSE_MESSAGE"
                 `);
             });
+
+            describe("when compositeStack is true", () => {
+                it("should set the stack to the combined error standardized stack", () => {
+                    // Arrange
+                    const cause = new Error("CAUSE_MESSAGE");
+                    const combinedErrorInfo = new ErrorInfo(
+                        "COMBINED_NAME",
+                        "COMBINED_MESSAGE",
+                        ["combinedstack1", "combinedstack2"],
+                    );
+                    jest.spyOn(
+                        ErrorInfo,
+                        "fromConsequenceAndCause",
+                    ).mockReturnValue(combinedErrorInfo);
+
+                    // Act
+                    const error = new KindError("MESSAGE", Errors.Unknown, {
+                        cause,
+                        compositeStack: true,
+                    });
+
+                    // Assert
+                    expect(error.stack).toBe(
+                        combinedErrorInfo.standardizedStack,
+                    );
+                });
+            });
+
+            describe.each([undefined, null, false])(
+                "when composite stack is %s",
+                (compositeStackValue) => {
+                    it("should set the stack to the normalized stack, not the combined stack", () => {
+                        // Arrange
+                        const normalizedErrorInfo = new ErrorInfo(
+                            "NORMALIZED_NAME",
+                            "NORMALIZED_MESSAGE",
+                            ["normalizedstack1", "normalizedstack2"],
+                        );
+                        jest.spyOn(ErrorInfo, "normalize").mockReturnValue(
+                            normalizedErrorInfo,
+                        );
+                        const cause = new Error("CAUSE_MESSAGE");
+                        const combinedErrorInfo = new ErrorInfo(
+                            "COMBINED_NAME",
+                            "COMBINED_MESSAGE",
+                            ["combinedstack1", "combinedstack2"],
+                        );
+                        jest.spyOn(
+                            ErrorInfo,
+                            "fromConsequenceAndCause",
+                        ).mockReturnValue(combinedErrorInfo);
+
+                        // Act
+                        const error = new KindError("MESSAGE", Errors.Unknown, {
+                            cause,
+                            compositeStack: compositeStackValue,
+                        });
+
+                        // Assert
+                        expect(error.stack).toBe(
+                            normalizedErrorInfo.standardizedStack,
+                        );
+                    });
+                },
+            );
         });
     });
 });

--- a/packages/wonder-stuff-core/src/__tests__/safe-stringify.test.js
+++ b/packages/wonder-stuff-core/src/__tests__/safe-stringify.test.js
@@ -2,57 +2,153 @@
 import {safeStringify} from "../safe-stringify.js";
 
 describe("#safeStringify", () => {
-    it.each([null, undefined])(
-        "should return the default for nullish values",
-        (value) => {
+    describe("without options or default value argument", () => {
+        it("should stringify the given value", () => {
             // Arrange
-            const defaultValue = "default";
+            const value = {
+                a: 1,
+                b: 2,
+            };
 
             // Act
-            const result = safeStringify(value, defaultValue);
+            const result = safeStringify(value);
+
+            // Assert
+            expect(result).toBe(JSON.stringify(value));
+        });
+    });
+
+    describe("with default value argument", () => {
+        it.each([null, undefined])(
+            "should return the default for nullish values",
+            (value) => {
+                // Arrange
+                const defaultValue = "default";
+
+                // Act
+                const result = safeStringify(value, defaultValue);
+
+                // Assert
+                expect(result).toBe(defaultValue);
+            },
+        );
+
+        it("should return the default if JSON.stringify errors", () => {
+            // Arrange
+            const defaultValue = "default";
+            jest.spyOn(JSON, "stringify").mockImplementation(() => {
+                throw new Error("error");
+            });
+
+            // Act
+            const result = safeStringify({}, defaultValue);
 
             // Assert
             expect(result).toBe(defaultValue);
-        },
-    );
-
-    it("should return the default if JSON.stringify errors", () => {
-        // Arrange
-        const defaultValue = "default";
-        jest.spyOn(JSON, "stringify").mockImplementation(() => {
-            throw new Error("error");
         });
 
-        // Act
-        const result = safeStringify({}, defaultValue);
+        it("should return the default if JSON.stringify returns a nullish value", () => {
+            // Arrange
+            const defaultValue = "default";
+            jest.spyOn(JSON, "stringify").mockReturnValue(undefined);
 
-        // Assert
-        expect(result).toBe(defaultValue);
+            // Act
+            const result = safeStringify({}, defaultValue);
+
+            // Assert
+            expect(result).toBe(defaultValue);
+        });
     });
 
-    it("should return the default if JSON.stringify returns a nullish value", () => {
-        // Arrange
-        const defaultValue = "default";
-        jest.spyOn(JSON, "stringify").mockReturnValue(undefined);
+    describe("with options argument", () => {
+        it.each([null, undefined])(
+            "should return the default for nullish values",
+            (value) => {
+                // Arrange
+                const options = {
+                    defaultValue: "default",
+                };
 
-        // Act
-        const result = safeStringify({}, defaultValue);
+                // Act
+                const result = safeStringify(value, options);
 
-        // Assert
-        expect(result).toBe(defaultValue);
-    });
+                // Assert
+                expect(result).toBe(options.defaultValue);
+            },
+        );
 
-    it("should stringify the given value", () => {
-        // Arrange
-        const value = {
-            a: 1,
-            b: 2,
-        };
+        it("should return the default if JSON.stringify errors", () => {
+            // Arrange
+            const options = {
+                defaultValue: "default",
+            };
+            jest.spyOn(JSON, "stringify").mockImplementation(() => {
+                throw new Error("error");
+            });
 
-        // Act
-        const result = safeStringify(value);
+            // Act
+            const result = safeStringify({}, options);
 
-        // Assert
-        expect(result).toBe(JSON.stringify(value));
+            // Assert
+            expect(result).toBe(options.defaultValue);
+        });
+
+        it("should return the default if JSON.stringify returns a nullish value", () => {
+            // Arrange
+            const options = {
+                defaultValue: "default",
+            };
+            jest.spyOn(JSON, "stringify").mockReturnValue(undefined);
+
+            // Act
+            const result = safeStringify({}, options.defaultValue);
+
+            // Assert
+            expect(result).toBe(options.defaultValue);
+        });
+
+        it("should not pretty format if the indent option is not given", () => {
+            // Arrange
+            const options = {};
+
+            // Act
+            const result = safeStringify({field: 1}, options);
+
+            // Assert
+            expect(result).not.toContain("\n");
+        });
+
+        it.each([null, undefined, 0])(
+            "should not pretty format if the indent option is %s",
+            (value) => {
+                // Arrange
+                const options = {
+                    indent: value,
+                };
+
+                // Act
+                const result = safeStringify({field: 1}, options);
+
+                // Assert
+                expect(result).not.toContain("\n");
+            },
+        );
+
+        it.each([2, 4])(
+            "should pretty format if the indent option is %s",
+            (value) => {
+                // Arrange
+                const options = {
+                    indent: value,
+                };
+                const expectedIndex = Array(value).fill(" ").join("");
+
+                // Act
+                const result = safeStringify({field: 1}, options);
+
+                // Assert
+                expect(result).toContain(`\n${expectedIndex}`);
+            },
+        );
     });
 });

--- a/packages/wonder-stuff-core/src/clone-metadata.js
+++ b/packages/wonder-stuff-core/src/clone-metadata.js
@@ -1,22 +1,6 @@
 // @flow
+import {clone} from "./clone.js";
 import type {Metadata} from "./types.js";
-
-const cloneValue = <T>(value: T): T => {
-    if (value != null && typeof value === "object") {
-        if (Array.isArray(value)) {
-            return value.map(cloneValue);
-        } else {
-            return Object.keys(value).reduce((acc, key) => {
-                acc[key] = cloneValue(value[key]);
-                return acc;
-                // We need to cast to any here so that the value is a valid
-                // match for T in the return type after the accumulator is done.
-                // $FlowIgnore[unclear-type]
-            }, ({}: any));
-        }
-    }
-    return value;
-};
 
 /**
  * Clone the given metadata.
@@ -33,10 +17,10 @@ export const cloneMetadata = <T: Metadata>(
     }
 
     // Clone the data.
-    const clone = cloneValue(metadata);
+    const clonedValue = clone(metadata);
 
     // We know that we have cloned the incoming data and so our clone is of
     // the correct type.
     // $FlowIgnore[incompatible-return]
-    return Object.freeze(clone);
+    return Object.freeze(clonedValue);
 };

--- a/packages/wonder-stuff-core/src/clone.js
+++ b/packages/wonder-stuff-core/src/clone.js
@@ -1,0 +1,26 @@
+// @flow
+
+/**
+ * Clone a value and all of its nested values.
+ *
+ * This produces a deep clone of a given value.
+ *
+ * @param {T} value The value to clone.
+ * @returns {T} The cloned value.
+ */
+export const clone = <T>(value: T): T => {
+    if (value != null && typeof value === "object") {
+        if (Array.isArray(value)) {
+            return value.map(clone);
+        } else {
+            return Object.keys(value).reduce((acc, key) => {
+                acc[key] = clone(value[key]);
+                return acc;
+                // We need to cast to any here so that the value is a valid
+                // match for T in the return type after the accumulator is done.
+                // $FlowIgnore[unclear-type]
+            }, ({}: any));
+        }
+    }
+    return value;
+};

--- a/packages/wonder-stuff-core/src/clone.js
+++ b/packages/wonder-stuff-core/src/clone.js
@@ -9,18 +9,19 @@
  * @returns {T} The cloned value.
  */
 export const clone = <T>(value: T): T => {
-    if (value != null && typeof value === "object") {
-        if (Array.isArray(value)) {
-            return value.map(clone);
-        } else {
-            return Object.keys(value).reduce((acc, key) => {
-                acc[key] = clone(value[key]);
-                return acc;
-                // We need to cast to any here so that the value is a valid
-                // match for T in the return type after the accumulator is done.
-                // $FlowIgnore[unclear-type]
-            }, ({}: any));
-        }
+    if (value == null || typeof value !== "object") {
+        return value;
     }
-    return value;
+
+    if (Array.isArray(value)) {
+        return value.map(clone);
+    }
+
+    return Object.keys(value).reduce((acc, key) => {
+        acc[key] = clone(value[key]);
+        return acc;
+        // We need to cast to any here so that the value is a valid
+        // match for T in the return type after the accumulator is done.
+        // $FlowIgnore[unclear-type]
+    }, ({}: any));
 };

--- a/packages/wonder-stuff-core/src/index.js
+++ b/packages/wonder-stuff-core/src/index.js
@@ -5,5 +5,6 @@ export {getKindFromError} from "./get-kind-from-error.js";
 export {getOriginalStackFromError} from "./get-original-stack-from-error.js";
 export {safeStringify} from "./safe-stringify.js";
 export {errorsFromError, Order} from "./errors-from-error.js";
+export {clone} from "./clone.js";
 
 export type {Metadata} from "./types.js";

--- a/packages/wonder-stuff-core/src/kind-error.js
+++ b/packages/wonder-stuff-core/src/kind-error.js
@@ -19,9 +19,9 @@ type Options = {|
     /**
      * Data to be attached to the error.
      *
-     * @type {?$ReadOnly<Metadata>}
+     * @type {?Metadata}
      */
-    metadata?: ?$ReadOnly<Metadata>,
+    metadata?: ?Metadata,
 
     /**
      * A prefix for the error name.

--- a/packages/wonder-stuff-core/src/kind-error.js
+++ b/packages/wonder-stuff-core/src/kind-error.js
@@ -50,6 +50,13 @@ type Options = {|
      * @type {?number}
      */
     minimumFrameCount?: ?number,
+
+    /**
+     * Should we create a composite stack from the causal error chain or not?
+     *
+     * @type {?boolean}
+     */
+    compositeStack?: ?boolean,
 |};
 
 /**
@@ -90,6 +97,8 @@ export class KindError extends Error {
      * @param {number} [options.minimumFrameCount=1] The minimum number of
      * stack frames to try and retain. This can be used to prevent stripping
      * all stack frames from the error's stack.
+     * @param {boolean} [options.compositeStack=false] Should we build a
+     * composite stack from the causal error chain or not?
      */
     constructor(
         message: string,
@@ -101,6 +110,7 @@ export class KindError extends Error {
             metadata,
             stripStackFrames,
             minimumFrameCount,
+            compositeStack,
         }: Options = {},
     ) {
         // Validate arguments.
@@ -165,14 +175,18 @@ export class KindError extends Error {
          */
         delete this.stack;
 
-        if (cause == null) {
-            // If there is no cause, so we just use the normalized stack.
-            // We don't use the normalized message here as we want to retain
-            // all lines of the message in this case.
-            this.stack = normalizedError.standardizedStack;
-        } else {
-            // We want to generate a better stack trace using the source error
-            // and our own stack.
+        // The default is the normalized stack.
+        // This may get replaced if there is a causal error and we want to
+        // use a composite stack.
+        // We don't use the normalized message here as we want to retain
+        // all lines of the message in this case.
+        this.stack = normalizedError.standardizedStack;
+
+        if (cause != null) {
+            // We want a better error message that reflects the causal error
+            // chain, and we might also want a composite stack built from
+            // those errors instead of the stack we have.
+
             // We don't normalize the cause as this should have happened already
             // when it was, itself, created with a cause.
             const causeInfo = ErrorInfo.from(cause);
@@ -181,11 +195,16 @@ export class KindError extends Error {
                 causeInfo,
             );
 
-            // We update our message to a standardized one from the combined
-            // stacks, giving us a nice causal relationship and we set our
-            // stack to the combined one.
+            // We update our message to a standardized one, giving us a nice
+            // causal relationship in the message.
             this.message = combined.message;
-            this.stack = combined.standardizedStack;
+
+            // And if we were asked to, we replace our stack with the
+            // composite stack built from the causal errors. Otherwise, we
+            // leave it with the normalized stack.
+            if (compositeStack === true) {
+                this.stack = combined.standardizedStack;
+            }
         }
     }
 }

--- a/packages/wonder-stuff-core/src/safe-stringify.js
+++ b/packages/wonder-stuff-core/src/safe-stringify.js
@@ -1,22 +1,81 @@
 // @flow
 
 /**
- * Stringify an item, returning an empty string on error, null, or undefined.
- *
- * @param {T} value The value to be stringified.
- * @param {string} [defaultValue=""] The default value to return if the value is
- * null, undefined, or not stringifiable.
- * @returns {string} The stringified value.
+ * Options to modify how a safe stringifying operation works.
  */
-export const safeStringify = <T>(
+type SafeStringifyOptions = {
+    /**
+     * A default string to use if the value cannot be stringified.
+     *
+     * @default '""' Empty string
+     * @type {string}
+     */
+    defaultValue?: string,
+
+    /**
+     * A number indicating how many spaces to indent nested structures.
+     * When not given, there will be no indentation nor additional newlines.
+     *
+     * @default undefined No indentation
+     * @type {?number}
+     */
+    indent?: ?number,
+};
+
+interface safeStringifyFn {
+    /**
+     * Stringify an item, returning an empty string on error, null, or undefined.
+     *
+     * @param {T} value The value to be stringified.
+     * @param {SafeStringifyOptions} [options] Options to modify the output.
+     * @param {string} [options.defaultValue = ""] A default value to return
+     * if the value to be stringified cannot be stringified.
+     * @param {string} [options.indent = undefined] A number indicating how
+     * many spaces to indent nested structures. When specified, values are
+     * stringified over multiple lines indented the specified amount for each
+     * scope of the object.
+     * @returns {string} The stringified value or the default value.
+     */
+    <T>(value: T, options?: SafeStringifyOptions): string;
+
+    /**
+     * Stringify an item, returning an empty string on error, null, or undefined.
+     *
+     * @param {T} value The value to be stringified.
+     * @param {string} [defaultValue=""] The default value to return if the value is
+     * null, undefined, or not stringifiable.
+     * @returns {string} The stringified value.
+     */
+    <T>(value: T, defaultValue?: string): string;
+}
+
+const getOptionsFromArg = (
+    defaultValueOrOptions: string | SafeStringifyOptions,
+): SafeStringifyOptions => {
+    if (
+        defaultValueOrOptions == null ||
+        typeof defaultValueOrOptions === "string"
+    ) {
+        return {
+            defaultValue: defaultValueOrOptions,
+        };
+    }
+
+    return defaultValueOrOptions;
+};
+
+export const safeStringify: safeStringifyFn = <T>(
     value: T,
-    defaultValue: string = "",
+    defaultValueOrOptions: string | SafeStringifyOptions = "",
 ): string => {
+    const {defaultValue = "", indent} = getOptionsFromArg(
+        defaultValueOrOptions,
+    );
     if (value == null) {
         return defaultValue;
     }
     try {
-        return JSON.stringify(value) ?? defaultValue;
+        return JSON.stringify(value, null, indent ?? undefined) ?? defaultValue;
     } catch (_) {
         return defaultValue;
     }

--- a/packages/wonder-stuff-core/src/safe-stringify.js
+++ b/packages/wonder-stuff-core/src/safe-stringify.js
@@ -75,7 +75,7 @@ export const safeStringify: safeStringifyFn = <T>(
         return defaultValue;
     }
     try {
-        return JSON.stringify(value, null, indent ?? undefined) ?? defaultValue;
+        return JSON.stringify(value, null, indent ?? 0) ?? defaultValue;
     } catch (_) {
         return defaultValue;
     }

--- a/packages/wonder-stuff-core/src/types.js
+++ b/packages/wonder-stuff-core/src/types.js
@@ -1,13 +1,13 @@
 // @flow
-type MetadataPrimitive = string | number | boolean;
+type MetadataPrimitive = string | number | boolean | null | void;
+type MetadataArray<T> = Array<T | MetadataArray<T>>;
 
 /**
  * A collection of data.
  */
 export type Metadata = {
-    [name: string]: ?(
+    [name: string]:
+        | Metadata
         | MetadataPrimitive
-        | $ReadOnly<Metadata>
-        | $ReadOnlyArray<?(MetadataPrimitive | Metadata)>
-    ),
+        | MetadataArray<MetadataPrimitive | Metadata>,
 };

--- a/packages/wonder-stuff-sentry/README.md
+++ b/packages/wonder-stuff-sentry/README.md
@@ -1,0 +1,5 @@
+# wonder-stuff-sentry
+
+This Wonder Stuff package provides support for integrating error flows with
+Sentry, allowing Sentry-specific metadata to be formatted into tags, contexts,
+and fingerprints when submitting to Sentry through a simple API.

--- a/packages/wonder-stuff-sentry/package.json
+++ b/packages/wonder-stuff-sentry/package.json
@@ -4,7 +4,7 @@
     },
     "name": "@khanacademy/wonder-stuff-sentry",
     "version": "0.1.1",
-    "description": "",
+    "description": "Sentry integration support",
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.js",

--- a/packages/wonder-stuff-sentry/package.json
+++ b/packages/wonder-stuff-sentry/package.json
@@ -9,7 +9,7 @@
     "main": "dist/index.js",
     "source": "src/index.js",
     "scripts": {
-        "test": "bash -c 'yarn --silent --cwd \"../..\" test $PWD'"
+        "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },
     "dependencies": {
         "@khanacademy/wonder-stuff-core": "^0.1.1"

--- a/packages/wonder-stuff-sentry/package.json
+++ b/packages/wonder-stuff-sentry/package.json
@@ -18,8 +18,8 @@
         "ws-dev-build-settings": "^0.0.3"
     },
     "browser": {
-        "dist/es/index.js": "dist/es/index.browser.js",
-        "dist/index.js": "dist/index.browser.js"
+        "dist/es/index.js": "./dist/es/index.browser.js",
+        "dist/index.js": "./dist/index.browser.js"
     },
     "author": "",
     "license": "MIT"

--- a/packages/wonder-stuff-sentry/src/__tests__/sentry-data-reducer.test.js
+++ b/packages/wonder-stuff-sentry/src/__tests__/sentry-data-reducer.test.js
@@ -45,7 +45,7 @@ describe("#sentryDataReducer", () => {
         it("should return object matching error's sentry data if accumulator is empty", () => {
             // Arrange
             jest.spyOn(Init, "getOptions").mockReturnValue(DefaultInitOptions);
-            const accumulator: SentryData = EmptySentryData;
+            const accumulator: SentryData = {...EmptySentryData};
             const error = new Error("test");
             const current: SentryData = {
                 tags: {
@@ -177,7 +177,7 @@ describe("#sentryDataReducer", () => {
         it("should return the error's data with additional context for the passed error", () => {
             // Arrange
             jest.spyOn(Init, "getOptions").mockReturnValue(DefaultInitOptions);
-            const accumulator: SentryData = EmptySentryData;
+            const accumulator: SentryData = {...EmptySentryData};
             const error = new Error("test");
             const current: SentryData = {
                 tags: {

--- a/packages/wonder-stuff-sentry/src/capture-error.js
+++ b/packages/wonder-stuff-sentry/src/capture-error.js
@@ -10,7 +10,7 @@ import type {SentryData} from "./types.js";
  * @param {Error} error The error to be captured.
  */
 export const captureError = (error: Error): void => {
-    const sentryData: SentryData = collateSentryData(error);
+    const sentryData: $ReadOnly<SentryData> = collateSentryData(error);
     const sentry = getSentry();
     sentry.withScope((scope) => {
         /**

--- a/packages/wonder-stuff-sentry/src/collate-sentry-data.js
+++ b/packages/wonder-stuff-sentry/src/collate-sentry-data.js
@@ -41,7 +41,7 @@ export const collateSentryData = (error: Error): $ReadOnly<SentryData> => {
     //    take precedent.
     // 2. Errors, regardless of whether they have sentryData, need to be
     //    given their own context in the data.
-    const collatedData: SentryData = consquenceAndCauses.reduceRight(
+    const collatedData: $ReadOnly<SentryData> = consquenceAndCauses.reduceRight(
         sentryDataReducer,
         EmptySentryData,
     );

--- a/packages/wonder-stuff-sentry/src/get-sentry-data-from-error.js
+++ b/packages/wonder-stuff-sentry/src/get-sentry-data-from-error.js
@@ -9,7 +9,9 @@ import type {SentryData} from "./types.js";
  * @returns {SentryData} The error's sentry data, or `null` if the error is not
  * a `KindSentryError` instance.
  */
-export const getSentryDataFromError = (error: Error): ?SentryData => {
+export const getSentryDataFromError = (
+    error: Error,
+): ?$ReadOnly<SentryData> => {
     if (error instanceof KindSentryError) {
         return error.sentryData;
     }

--- a/packages/wonder-stuff-sentry/src/kind-sentry-error.js
+++ b/packages/wonder-stuff-sentry/src/kind-sentry-error.js
@@ -20,18 +20,18 @@ type Options = {
      *
      * This data will be added to the Sentry scope when using `captureError`.
      *
-     * @type {?$ReadOnly<$Partial<SentryData>>}
+     * @type {?$Partial<SentryData>}
      */
-    sentryData?: ?$ReadOnly<$Partial<SentryData>>,
+    sentryData?: ?$Partial<SentryData>,
 
     /**
      * Other data to be attached to the error.
      *
      * This data will not be added to Sentry when using `captureError`.
      *
-     * @type {?$ReadOnly<Metadata>}
+     * @type {?Metadata}
      */
-    metadata?: ?$ReadOnly<Metadata>,
+    metadata?: ?Metadata,
 
     /**
      * A prefix to be added to the error name.
@@ -89,7 +89,7 @@ export class KindSentryError extends KindError {
      * Defaults to `Errors.Unknown`.
      * @param {Options} [options] Options for constructing the error.
      * @param {Error} [options.cause] The error that caused this error.
-     * @param {$ReadOnly<Metadata>} [options.metadata] The metadata to attach
+     * @param {Metadata} [options.metadata] The metadata to attach
      * to the error.
      * @param {string} [options.prefix=""] A prefix to prepend the name of the
      * error.
@@ -129,6 +129,28 @@ export class KindSentryError extends KindError {
             // For simplicity of implementation and ease of API use, we choose
             // option 1.
             metadata: {
+                // Flow is unhappy because:
+                // 1. metadata is of type Metadata, which can have a variety of
+                //    value types, such as string and number.
+                // 2. metadata is mutable and as such, something that is type
+                //    string could be given a value of type number at some
+                //    later point.
+                // 3. sentryData (and EmptySentryData) are of type SentryData,
+                //    and some of their types are stricter about what types
+                //    they can have, such as only string.
+                // 4. once sentryData things are part of metadata, sentryData
+                //    things could be mutated to the wrong type.
+                // 5. Flow doesn't know that we will clone and freeze the
+                //    metadata once we pass it into this super constructor here.
+                //
+                // We could mitigate by making metadata readonly for the base
+                // class, but that just pushes the problem on.
+                // And we could create a whole new object explicitly copying
+                // each bit of data into a new one of the correct type, but
+                // since we are about to clone and freeze the data in the base
+                // class, that seems like overkill, so let's just suppress
+                // flow.
+                // $FlowIgnore[incompatible-call]
                 sentry: {
                     // We set the defaults here so that we know these will be
                     // there, even if they're empty.

--- a/packages/wonder-stuff-sentry/src/kind-sentry-error.js
+++ b/packages/wonder-stuff-sentry/src/kind-sentry-error.js
@@ -16,14 +16,18 @@ type Options = {
     cause?: ?Error,
 
     /**
-     * Data to be attached to the error that would be reported to Sentry.
+     * Sentry tags, contexts, and fingerprint information to be attached.
+     *
+     * This data will be added to the Sentry scope when using `captureError`.
      *
      * @type {?$ReadOnly<$Partial<SentryData>>}
      */
     sentryData?: ?$ReadOnly<$Partial<SentryData>>,
 
     /**
-     * Data to be attached to the error that will not get reported to Sentry.
+     * Other data to be attached to the error.
+     *
+     * This data will not be added to Sentry when using `captureError`.
      *
      * @type {?$ReadOnly<Metadata>}
      */
@@ -56,6 +60,13 @@ type Options = {
      * @type {?number}
      */
     minimumFrameCount?: ?number,
+
+    /**
+     * Should we create a composite stack from the causal error chain or not?
+     *
+     * @type {?boolean}
+     */
+    compositeStack?: ?boolean,
 };
 
 /**
@@ -68,6 +79,32 @@ type Options = {
  * @extends {KindError}
  */
 export class KindSentryError extends KindError {
+    /**
+     *Creates an instance of KindSentryError.
+
+     * @memberof KindSentryError
+     * @param {string} message The error message.
+     * @param {string} [kind] The kind of error. This will be combined with
+     * `prefix` to form the name of the error, i.e. PrefixSentryKindError.
+     * Defaults to `Errors.Unknown`.
+     * @param {Options} [options] Options for constructing the error.
+     * @param {Error} [options.cause] The error that caused this error.
+     * @param {$ReadOnly<Metadata>} [options.metadata] The metadata to attach
+     * to the error.
+     * @param {string} [options.prefix=""] A prefix to prepend the name of the
+     * error.
+     * @param {string} [options.name="Error"] The name of the error.
+     * @param {number} [options.stripStackFrames=0] The number of stack frames
+     * to remove from the error's stack. This can be used to ensure that the top
+     * call of the stack references the point at which an error is thrown which
+     * can be useful when helper functions are used to build the error being
+     * thrown.
+     * @param {number} [options.minimumFrameCount=1] The minimum number of
+     * stack frames to try and retain. This can be used to prevent stripping
+     * all stack frames from the error's stack.
+     * @param {boolean} [options.compositeStack=false] Should we build a
+     * composite stack from the causal error chain or not?
+     */
     constructor(
         message: string,
         kind: string = Errors.Unknown,

--- a/packages/wonder-stuff-sentry/src/types.js
+++ b/packages/wonder-stuff-sentry/src/types.js
@@ -85,7 +85,6 @@ type SentrySeverity =
 
 interface SentryScope {
     setTags(tags: $ReadOnly<{|[key: string]: string|}>): void;
-    setTag(tag: string, value: string): void;
     setFingerprint(fingerprint: $ReadOnlyArray<string>): void;
     setContext(
         name: string,

--- a/packages/wonder-stuff-sentry/src/types.js
+++ b/packages/wonder-stuff-sentry/src/types.js
@@ -15,7 +15,7 @@ export type SentryTags = {
  *
  * The key of each item is the name of a field within the context.
  */
-export type SentryContext = $ReadOnly<Metadata>;
+export type SentryContext = Metadata;
 
 /**
  * Named contexts for a Sentry event.
@@ -23,21 +23,28 @@ export type SentryContext = $ReadOnly<Metadata>;
  * The key of each item is the name of the context.
  */
 export type SentryContexts = {
-    [name: string]: $ReadOnly<SentryContext>,
+    [name: string]: SentryContext,
 };
+
+/**
+ * A Sentry fingerprint.
+ *
+ * This is an array of strings.
+ */
+export type SentryFingerprint = Array<string>;
 
 /**
  * Data to be sent to sentry.
  *
  * @typedef {Object} SentryData
- * @property {?$ReadOnly<SentryTags>} tags The tags to add for the associated sentry event.
+ * @property {SentryTags} tags The tags to add for the associated sentry event.
  * This is equivalent to using the `setTag` and `setTags` APIs.
- * @property {?$ReadOnly<SentryContexts>} contexts The contexts to add for the associated
+ * @property {SentryContexts} contexts The contexts to add for the associated
  * sentry event.
  * This is equivalent to using the `setContext` API.
  * NOTE: `setExtras` is deprecated. For similar behavior, use a context keyed as
  * `"Additional Data"`.
- * @property {?$ReadOnlyArray<string>} fingerprint The fingerprint of the
+ * @property {Array<string>} fingerprint The fingerprint of the
  * associated sentry event.
  * This is equivalent to using the `setFingerprint` API.
  */
@@ -46,28 +53,28 @@ export type SentryData = {|
      * This is passed to setTags on the sentry scope.
      * Tags help categorize things.
      */
-    +tags: $ReadOnly<SentryTags>,
+    tags: SentryTags,
 
     /**
      * These are each passed to setContext on the sentry scope.
      * Contexts create a new headed section in the sentry report.
      * Useful for grouping specific context together.
      */
-    +contexts: $ReadOnly<SentryContexts>,
+    contexts: SentryContexts,
 
     /**
      * This is passed to setFingerprint on the sentry scope.
      * The fingerprint helps group like messages that otherwise would not
      * get grouped.
      */
-    +fingerprint: $ReadOnlyArray<string>,
+    fingerprint: SentryFingerprint,
 |};
 
 export type InitOptions = {
-    kindTagName: string,
-    groupByTagName: string,
-    concatenatedMessageTagName: string,
-    causalErrorContextPrefix: string,
+    +kindTagName: string,
+    +groupByTagName: string,
+    +concatenatedMessageTagName: string,
+    +causalErrorContextPrefix: string,
 };
 
 /////////////////////////////////////////////
@@ -86,7 +93,7 @@ type SentrySeverity =
 interface SentryScope {
     setTags(tags: {|[key: string]: string|}): SentryScope;
     setFingerprint(fingerprint: Array<string>): SentryScope;
-    setContext(name: string, context: {|[key: string]: mixed|}): SentryScope;
+    setContext(name: string, context: SentryContext): SentryScope;
 }
 
 /**

--- a/packages/wonder-stuff-sentry/src/types.js
+++ b/packages/wonder-stuff-sentry/src/types.js
@@ -98,8 +98,8 @@ interface SentryScope {
  * This is the interface that Sentry implementations must expose for us to call.
  */
 export interface UnifiedSentryAPI {
-    withScope(callback: (scope: SentryScope) => void): void;
-    captureException(message: Error, severity?: SentrySeverity): void;
+    withScope(callback: (scope: SentryScope) => void): mixed;
+    captureException(message: Error, severity?: SentrySeverity): mixed;
 }
 // <- Sentry-specific types above this point.
 /////////////////////////////////////////////

--- a/packages/wonder-stuff-sentry/src/types.js
+++ b/packages/wonder-stuff-sentry/src/types.js
@@ -84,12 +84,12 @@ type SentrySeverity =
     | "critical";
 
 interface SentryScope {
-    setTags(tags: $ReadOnly<{|[key: string]: string|}>): void;
-    setFingerprint(fingerprint: $ReadOnlyArray<string>): void;
+    setTags(tags: $ReadOnly<{|[key: string]: string|}>): SentryScope;
+    setFingerprint(fingerprint: $ReadOnlyArray<string>): SentryScope;
     setContext(
         name: string,
         context: $ReadOnly<{|[key: string]: mixed|}>,
-    ): void;
+    ): SentryScope;
 }
 
 /**

--- a/packages/wonder-stuff-sentry/src/types.js
+++ b/packages/wonder-stuff-sentry/src/types.js
@@ -84,12 +84,9 @@ type SentrySeverity =
     | "critical";
 
 interface SentryScope {
-    setTags(tags: $ReadOnly<{|[key: string]: string|}>): SentryScope;
-    setFingerprint(fingerprint: $ReadOnlyArray<string>): SentryScope;
-    setContext(
-        name: string,
-        context: $ReadOnly<{|[key: string]: mixed|}>,
-    ): SentryScope;
+    setTags(tags: {|[key: string]: string|}): SentryScope;
+    setFingerprint(fingerprint: Array<string>): SentryScope;
+    setContext(name: string, context: {|[key: string]: mixed|}): SentryScope;
 }
 
 /**

--- a/utils/pre-publish-check.js
+++ b/utils/pre-publish-check.js
@@ -44,8 +44,8 @@ const checkPackageEntrypoints = (pkgJson) => {
     checkPackageField(pkgJson, "main", "dist/index.js");
     if (pkgJson.browser) {
         const expectedValue = {
-            [pkgJson.main]: "dist/index.browser.js",
-            [pkgJson.module]: "dist/es/index.browser.js",
+            [pkgJson.main]: "./dist/index.browser.js",
+            [pkgJson.module]: "./dist/es/index.browser.js",
         };
 
         for (const key of Object.keys(pkgJson.browser)) {


### PR DESCRIPTION
## Summary:
This makes some tweaks to our Wonder Stuff APIs based on observations made when integrating it into webapp.

1. Fixes a bug in the `browser` property of package.json files so that the mapped paths are legitimate (updated build to properly assert this too)
1. Made composite stacks an optional feature (off by default).
1. Added return types for the sentry APIs to support common Sentry API definitions
1. Less read-only types so that callers don't have to work out how to make that work nicely
1. We export `clone` per an earlier review comment
1. Added `index.d.ts` to packages so that the JSDocs will show up for folks consuming our code (does not require TypeScript - this is a docs-only thing)
1. Updated test run script for packages so that folks can, to some degree, just run the tests they want with the options they want (given that this still runs from the root, eventually, saying `yarn test error`, for example, will run matching tests in any package, not just the one where the command was executed)

Issue: FEI-4142

## Test plan:
`yarn test`
`yarn flow`