### PR TITLE
[fei4142.3] Add option to stringify nested context object and array values

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -74,8 +74,8 @@ jobs:
     - name: Check Builds
       uses: preactjs/compressed-size-action@v2
       with:
-        # Any JS files anywhere within a dist directory:
-        pattern: "**/dist/**/*.js"
+        # We only care about the browser ES module size, really:
+        pattern: "**/dist/es/index.browser.js"
         # Always ignore SourceMaps and node_modules:
         exclude: "{**/*.map,**/node_modules/**}"
         # Clean up before a build

--- a/packages/wonder-stuff-sentry/src/__tests__/stringify-nested-contexts.test.js
+++ b/packages/wonder-stuff-sentry/src/__tests__/stringify-nested-contexts.test.js
@@ -1,0 +1,57 @@
+// @flow
+import {stringifyNestedContexts} from "../stringify-nested-contexts.js";
+
+describe("#stringifyNestedContexts", () => {
+    it("should not stringify top-level objects, arrays, or nested primitives", () => {
+        // Arrange
+        const input = {
+            context1: {
+                foo: "bar",
+                baz: [1, 2, 3],
+                qux: {
+                    quux: "corge",
+                },
+            },
+        };
+
+        // Act
+        const result = stringifyNestedContexts(input);
+
+        // Assert
+        expect(result).toStrictEqual(input);
+    });
+
+    it("should stringify objects and arrays nested inside top-level objects and arrays", () => {
+        // Arrange
+        const input = {
+            context1: {
+                foo: {
+                    baz: [1, 2, 3],
+                    bar: {
+                        bingo: "bango",
+                    },
+                },
+                qux: [
+                    {
+                        quux: "corge",
+                    },
+                    [1, 2, 3],
+                ],
+            },
+        };
+
+        // Act
+        const result = stringifyNestedContexts(input);
+
+        // Assert
+        expect(result).toStrictEqual({
+            context1: {
+                foo: {
+                    baz: "[1,2,3]",
+                    bar: '{"bingo":"bango"}',
+                },
+                qux: ['{"quux":"corge"}', "[1,2,3]"],
+            },
+        });
+    });
+});

--- a/packages/wonder-stuff-sentry/src/default-kind-error-data-options.js
+++ b/packages/wonder-stuff-sentry/src/default-kind-error-data-options.js
@@ -9,4 +9,5 @@ export const DefaultKindErrorDataOptions: KindErrorDataOptions = {
     groupByTagName: "group_by_message",
     concatenatedMessageTagName: "concatenated_message",
     causalErrorContextPrefix: "Source Error - ",
+    stringifyNestedContext: false,
 };

--- a/packages/wonder-stuff-sentry/src/kind-error-data.js
+++ b/packages/wonder-stuff-sentry/src/kind-error-data.js
@@ -17,8 +17,11 @@ export class KindErrorData implements SentryIntegration {
     name: string = KindErrorData.id;
     +_options: KindErrorDataOptions;
 
-    constructor(options: KindErrorDataOptions = DefaultKindErrorDataOptions) {
-        this._options = options;
+    constructor(options: $Partial<KindErrorDataOptions> = Object.freeze({})) {
+        this._options = {
+            ...DefaultKindErrorDataOptions,
+            ...options,
+        };
     }
 
     setupOnce(

--- a/packages/wonder-stuff-sentry/src/kind-error-data.js
+++ b/packages/wonder-stuff-sentry/src/kind-error-data.js
@@ -9,6 +9,7 @@ import type {
 } from "./types.js";
 
 import {collateSentryData} from "./collate-sentry-data.js";
+import {stringifyNestedContexts} from "./stringify-nested-contexts.js";
 import {DefaultKindErrorDataOptions} from "./default-kind-error-data-options.js";
 
 export class KindErrorData implements SentryIntegration {
@@ -69,10 +70,18 @@ export class KindErrorData implements SentryIntegration {
          *
          * We now output all the contexts to the scope.
          */
-        event.contexts = {
+        const updatedContexts = {
             ...event.contexts,
             ...contexts,
         };
+        /**
+         * We may need to iterate our context objects and replace with
+         * a stringified version, any arrays and objects nested more than
+         * 1 level deep in each context.
+         */
+        event.contexts = this._options.stringifyNestedContext
+            ? stringifyNestedContexts(updatedContexts)
+            : updatedContexts;
 
         /**
          * Fingerprint helps group like messages that otherwise would not

--- a/packages/wonder-stuff-sentry/src/stringify-nested-contexts.js
+++ b/packages/wonder-stuff-sentry/src/stringify-nested-contexts.js
@@ -1,0 +1,38 @@
+// @flow
+import {safeStringify} from "@khanacademy/wonder-stuff-core";
+import type {SentryContexts} from "./types.js";
+
+export const stringifyNestedContexts = (
+    contexts: SentryContexts,
+): SentryContexts => {
+    const stringifiedContexts = {};
+
+    // For each context,
+    for (const [key, value] of Object.entries(contexts)) {
+        stringifiedContexts[key] = {};
+
+        // For each top-level property of a context (each context is an object).
+        // $FlowIgnore[incompatible-call]
+        for (const [subKey, subValue] of Object.entries(value)) {
+            if (typeof subValue === "object") {
+                if (Array.isArray(subValue)) {
+                    stringifiedContexts[key][subKey] = subValue.map((v) =>
+                        typeof v === "object" ? safeStringify(v) : v,
+                    );
+                } else {
+                    stringifiedContexts[key][subKey] = Object.entries(
+                        // We know that subValue is an object.
+                        // $FlowIgnore[incompatible-call]
+                        subValue,
+                    ).reduce((acc, [k, v]) => {
+                        acc[k] = typeof v === "object" ? safeStringify(v) : v;
+                        return acc;
+                    }, {});
+                }
+            } else {
+                stringifiedContexts[key] = value;
+            }
+        }
+    }
+    return stringifiedContexts;
+};

--- a/packages/wonder-stuff-sentry/src/types.js
+++ b/packages/wonder-stuff-sentry/src/types.js
@@ -95,6 +95,16 @@ export type KindErrorDataOptions = {
 
     // TODO(somewhatabstract): Allow configuration of which fields we include
     // in causal error contexts.
+
+    /**
+     * Whether to stringify nested context data or not.
+     *
+     * If true, any arrays or objects that are more than one level deep in the
+     * context data hierarchy will be stringified so that they are easily
+     * readable in Sentry (it seems that Sentry doesn't expand nested data,
+     * possibly down to the plan being used).
+     */
+    +stringifyNestedContext: boolean,
 };
 
 /////////////////////////////////////////////


### PR DESCRIPTION
## Summary:
Sentry (at least on the plan we have) doesn't expand objects and arrays nested more than one level deep in contexts. This allows us to stringify these things so that they are still readable in the Sentry UX.

### Before:
![image](https://user-images.githubusercontent.com/1266297/141857780-35e0590a-6764-4be9-a488-a337eb61f570.png)

### After:
![image](https://user-images.githubusercontent.com/1266297/141862273-c792e368-da85-49b6-9994-cf7267c5d4d0.png)

Issue: FEI-4142

## Test plan:
`yarn test`
`yarn flow`
Integrate into webapp and demo it working.