### PR TITLE
[wstesting] Add wonder-stuff-testing and isolateModules helper

### DIFF
--- a/packages/wonder-stuff-testing/.babelrc.js
+++ b/packages/wonder-stuff-testing/.babelrc.js
@@ -1,0 +1,8 @@
+/**
+ * HACK(somewhatabstract): Due to https://github.com/facebook/jest/issues/11741,
+ * we need to have this file, or updating inline snapshots can fail rather
+ * cryptically.
+ *
+ * We should remove this when jest is fixed.
+ */
+module.exports = require("../../build-settings/babel.config.js");

--- a/packages/wonder-stuff-testing/README.md
+++ b/packages/wonder-stuff-testing/README.md
@@ -1,0 +1,3 @@
+# wonder-stuff-testing
+
+This Wonder Stuff package contains utilities to assist in testing.

--- a/packages/wonder-stuff-testing/package.json
+++ b/packages/wonder-stuff-testing/package.json
@@ -1,0 +1,23 @@
+{
+    "publishConfig": {
+        "access": "public"
+    },
+    "name": "@khanacademy/wonder-stuff-testing",
+    "version": "0.0.1",
+    "description": "Utilities for use in testing",
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.js",
+    "scripts": {
+        "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
+    },
+    "devDependencies": {
+        "ws-dev-build-settings": "^0.0.4"
+    },
+    "browser": {
+        "dist/es/index.js": "./dist/es/index.browser.js",
+        "dist/index.js": "./dist/index.browser.js"
+    },
+    "author": "",
+    "license": "MIT"
+}

--- a/packages/wonder-stuff-testing/src/index.js
+++ b/packages/wonder-stuff-testing/src/index.js
@@ -1,0 +1,2 @@
+// @flow
+export {isolateModules} from "./jest/isolate-modules.js";

--- a/packages/wonder-stuff-testing/src/jest/__tests__/isolate-modules.test.js
+++ b/packages/wonder-stuff-testing/src/jest/__tests__/isolate-modules.test.js
@@ -1,0 +1,47 @@
+// @flow
+import {isolateModules} from "../isolate-modules.js";
+
+describe("#isolateModules", () => {
+    it("should execute the given function", () => {
+        // Arrange
+        const action = jest.fn();
+
+        // Act
+        isolateModules(action);
+
+        // Assert
+        expect(action).toHaveBeenCalled();
+    });
+
+    it("should return the result of the given function", () => {
+        // Arrange
+        const action = jest.fn(() => "result");
+
+        // Act
+        const result = isolateModules(action);
+
+        // Assert
+        expect(result).toEqual("result");
+    });
+
+    it("should isolate module imports inside the executed code from existing imports", async () => {
+        // Arrange
+
+        // Act
+        const result = isolateModules(() => require("../isolate-modules.js"));
+
+        // Assert
+        expect(result).not.toBe(isolateModules);
+    });
+
+    it("should isolate module imports inside the executed code from other isolated imports", async () => {
+        // Arrange
+        const module1 = isolateModules(() => require("../isolate-modules.js"));
+
+        // Act
+        const result = isolateModules(() => require("../isolate-modules.js"));
+
+        // Assert
+        expect(module1).not.toBe(result);
+    });
+});

--- a/packages/wonder-stuff-testing/src/jest/isolate-modules.js
+++ b/packages/wonder-stuff-testing/src/jest/isolate-modules.js
@@ -1,0 +1,31 @@
+// @flow
+// Opt this file out of coverage because it's super hard to test.
+/* istanbul ignore file */
+
+/**
+ * Isolate imports within a given action using jest.isolateModules.
+ *
+ * This is a helper for the `jest.isolateModules` API, allowing
+ * code to avoid the clunky closure syntax in their tests.
+ *
+ * @param {() => T} action The action that contains the isolated module imports.
+ * We do it this way so that any `require` calls are relative to the calling
+ * code and not this function. Note that we don't support promises here to
+ * discourage dynamic `import` use, which doesn't play well with standard
+ * jest yet.
+ */
+export const isolateModules = <T>(action: () => T): T => {
+    if (typeof jest === "undefined") {
+        throw new Error(`jest is not defined; make sure you are running jest`);
+    }
+
+    let result = undefined;
+    jest.isolateModules(() => {
+        result = action();
+    });
+    // We know that we'll have a result of the appropriate type at this point.
+    // We could use a promise to make everything happy, but this doesn't need
+    // to be async, so why bother.
+    // $FlowIgnore[incompatible-return]
+    return result;
+};

--- a/packages/wonder-stuff-testing/src/jest/isolate-modules.js
+++ b/packages/wonder-stuff-testing/src/jest/isolate-modules.js
@@ -1,7 +1,4 @@
 // @flow
-// Opt this file out of coverage because it's super hard to test.
-/* istanbul ignore file */
-
 /**
  * Isolate imports within a given action using jest.isolateModules.
  *
@@ -15,6 +12,9 @@
  * jest yet.
  */
 export const isolateModules = <T>(action: () => T): T => {
+    // We can't test this inside jest, since jest will exist and it's not
+    // worth jumping through hoops to make a test work.
+    /* istanbul ignore if */
     if (typeof jest === "undefined") {
         throw new Error(`jest is not defined; make sure you are running jest`);
     }


### PR DESCRIPTION
## Summary:
There are likely more things to go in this package moving forward, but for now, this helper

Issue: XXX-XXXX

## Test plan:
`yarn test`