### PR TITLE
[wait] Add wait() to WS testing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ flow-typed/**/*.js
 coverage
 **/dist
 **/*.template
+**/package.json

--- a/packages/wonder-stuff-testing/package.json
+++ b/packages/wonder-stuff-testing/package.json
@@ -14,6 +14,9 @@
     "devDependencies": {
         "ws-dev-build-settings": "^0.0.4"
     },
+    "peerDependencies": {
+        "@khanacademy/wonder-stuff-core": "^0.1.2"
+    },
     "browser": {
         "dist/es/index.js": "./dist/es/index.browser.js",
         "dist/index.js": "./dist/index.browser.js"

--- a/packages/wonder-stuff-testing/src/errors.js
+++ b/packages/wonder-stuff-testing/src/errors.js
@@ -1,0 +1,7 @@
+// @flow
+import {Errors as CoreErrors} from "@khanacademy/wonder-stuff-core";
+
+export const Errors = Object.freeze({
+    ...CoreErrors,
+    InvalidUse: "InvalidUse",
+});

--- a/packages/wonder-stuff-testing/src/index.js
+++ b/packages/wonder-stuff-testing/src/index.js
@@ -1,2 +1,2 @@
 // @flow
-export {isolateModules} from "./jest/isolate-modules.js";
+export * as jest from "./jest/index.js";

--- a/packages/wonder-stuff-testing/src/jest/__tests__/isolate-modules.test.js
+++ b/packages/wonder-stuff-testing/src/jest/__tests__/isolate-modules.test.js
@@ -5,12 +5,12 @@ import * as AssertJest from "../internal/assert-jest.js";
 jest.mock("../internal/assert-jest.js");
 
 describe("#isolateModules", () => {
-    it("should assert we are in jest on import", () => {
+    it("should assert we are in jest", () => {
         // Arrange
         const assertJestSpy = jest.spyOn(AssertJest, "assertJest");
 
         // Act
-        isolateModules(() => jest.requireActual("../wait.js"));
+        isolateModules(() => {});
 
         // Assert
         expect(assertJestSpy).toHaveBeenCalledTimes(1);

--- a/packages/wonder-stuff-testing/src/jest/__tests__/isolate-modules.test.js
+++ b/packages/wonder-stuff-testing/src/jest/__tests__/isolate-modules.test.js
@@ -1,7 +1,21 @@
 // @flow
 import {isolateModules} from "../isolate-modules.js";
+import * as AssertJest from "../internal/assert-jest.js";
+
+jest.mock("../internal/assert-jest.js");
 
 describe("#isolateModules", () => {
+    it("should assert we are in jest on import", () => {
+        // Arrange
+        const assertJestSpy = jest.spyOn(AssertJest, "assertJest");
+
+        // Act
+        isolateModules(() => jest.requireActual("../wait.js"));
+
+        // Assert
+        expect(assertJestSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("should execute the given function", () => {
         // Arrange
         const action = jest.fn();

--- a/packages/wonder-stuff-testing/src/jest/__tests__/wait.test.js
+++ b/packages/wonder-stuff-testing/src/jest/__tests__/wait.test.js
@@ -1,0 +1,61 @@
+/* eslint-disable no-console */
+// @flow
+import {wait} from "../wait.js";
+
+describe("#wait", () => {
+    it("should throw immediately when jest.useFakeTimers", () => {
+        // Arrange
+        jest.useFakeTimers();
+
+        // Act
+        const underTest = () => wait();
+
+        // Assert
+        expect(underTest).toThrowErrorMatchingInlineSnapshot(
+            `"Cannot use wait() with fake timers. Call jest.useRealTimers() in test case or in a beforeEach."`,
+        );
+    });
+
+    it("should resolve when jest.useRealTimers", async () => {
+        // Arrange
+        jest.useRealTimers();
+
+        // Act
+        const underTest = wait();
+
+        // Assert
+        await expect(underTest).resolves.toBeUndefined();
+    });
+
+    it("should not invoke a spied on console.warn for the test case", async () => {
+        // Arrange
+        jest.useRealTimers();
+        const warnSpy = jest
+            .spyOn(console, "warn")
+            .mockImplementation(() => {});
+
+        // Act
+        await wait();
+
+        // Assert
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not override console.warn for the test case", async () => {
+        // Arrange
+        jest.useRealTimers();
+        const warnSpy = jest
+            .spyOn(console, "warn")
+            .mockImplementation(() => {});
+
+        // Act
+        console.warn("before");
+        await wait();
+        console.warn("after");
+
+        // Assert
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+        expect(warnSpy).toHaveBeenCalledWith("before");
+        expect(warnSpy).toHaveBeenCalledWith("after");
+    });
+});

--- a/packages/wonder-stuff-testing/src/jest/__tests__/wait.test.js
+++ b/packages/wonder-stuff-testing/src/jest/__tests__/wait.test.js
@@ -1,7 +1,5 @@
 // @flow
-import {isolateModules} from "../isolate-modules.js";
 import {wait, waitForAnimationFrame} from "../wait.js";
-import * as AssertJest from "../internal/assert-jest.js";
 import * as VerifyRealTimers from "../internal/verify-real-timers.js";
 import * as UnverifiedWait from "../internal/unverified-wait.js";
 
@@ -10,17 +8,6 @@ jest.mock("../internal/verify-real-timers.js");
 jest.mock("../internal/unverified-wait.js");
 
 describe("wait.js", () => {
-    it("should assert we are in jest on import", () => {
-        // Arrange
-        const assertJestSpy = jest.spyOn(AssertJest, "assertJest");
-
-        // Act
-        isolateModules(() => jest.requireActual("../wait.js"));
-
-        // Assert
-        expect(assertJestSpy).toHaveBeenCalledTimes(1);
-    });
-
     describe("#wait", () => {
         it("should verify if jest.useRealTimers or not", () => {
             // Arrange

--- a/packages/wonder-stuff-testing/src/jest/index.js
+++ b/packages/wonder-stuff-testing/src/jest/index.js
@@ -1,0 +1,3 @@
+// @flow
+export {isolateModules} from "./isolate-modules.js";
+export {wait} from "./wait.js";

--- a/packages/wonder-stuff-testing/src/jest/internal/__tests__/assert-jest.test.js
+++ b/packages/wonder-stuff-testing/src/jest/internal/__tests__/assert-jest.test.js
@@ -1,0 +1,31 @@
+// @flow
+import {assertJest} from "../assert-jest.js";
+import * as IsRunningInJest from "../is-running-in-jest.js";
+
+jest.mock("../is-running-in-jest.js");
+
+describe("#assertJest", () => {
+    it("should throw if we are not in jest", () => {
+        // Arrange
+        jest.spyOn(IsRunningInJest, "isRunningInJest").mockReturnValue(false);
+
+        // Act
+        const act = () => assertJest();
+
+        // Assert
+        expect(act).toThrowErrorMatchingInlineSnapshot(
+            `"Invalid import - for use in tests only"`,
+        );
+    });
+
+    it("should not throw if we are in jest", () => {
+        // Arrange
+        jest.spyOn(IsRunningInJest, "isRunningInJest").mockReturnValue(true);
+
+        // Act
+        const act = () => assertJest();
+
+        // Assert
+        expect(act).not.toThrow();
+    });
+});

--- a/packages/wonder-stuff-testing/src/jest/internal/__tests__/unverified-wait.test.js
+++ b/packages/wonder-stuff-testing/src/jest/internal/__tests__/unverified-wait.test.js
@@ -1,0 +1,61 @@
+// @flow
+import {unverifiedWait} from "../unverified-wait.js";
+
+describe("#unverifiedWait", () => {
+    const RealPromise = global.Promise;
+    beforeEach(() => {
+        jest.useRealTimers();
+    });
+
+    afterEach(() => {
+        global.Promise = RealPromise;
+    });
+
+    it("should invoke setTimeout with the given delay", async () => {
+        // Arrange
+        const setTimeoutSpy = jest
+            .spyOn(global, "setTimeout")
+            .mockImplementation((fn) => fn());
+
+        // Act
+        await unverifiedWait(42, 1);
+
+        // Assert
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 42);
+    });
+
+    it("should invoke setTimeout count times", async () => {
+        // Arrange
+        const setTimeoutSpy = jest
+            .spyOn(global, "setTimeout")
+            .mockImplementation((fn) => fn());
+
+        // Act
+        await unverifiedWait(1, 42);
+
+        // Assert
+        expect(setTimeoutSpy).toHaveBeenCalledTimes(42);
+    });
+
+    it("should resolve one promise per count", async () => {
+        // Arrange
+        jest.spyOn(global, "setTimeout").mockImplementation((fn) => fn());
+
+        const countResolves = jest.fn();
+        global.Promise = jest.fn().mockImplementation((fn) => {
+            return new RealPromise((resolve, reject) => {
+                const countedResolve = () => {
+                    countResolves();
+                    resolve();
+                };
+                fn(countedResolve, reject);
+            });
+        });
+
+        // Act
+        await unverifiedWait(1, 42);
+
+        // Assert
+        expect(countResolves).toHaveBeenCalledTimes(42);
+    });
+});

--- a/packages/wonder-stuff-testing/src/jest/internal/__tests__/verify-real-timers.test.js
+++ b/packages/wonder-stuff-testing/src/jest/internal/__tests__/verify-real-timers.test.js
@@ -1,8 +1,20 @@
 /* eslint-disable no-console */
 // @flow
+import * as AssertJest from "../assert-jest.js";
 import {verifyRealTimers} from "../verify-real-timers.js";
 
 describe("#verifyRealTimers", () => {
+    it("should assert we are in jest", () => {
+        // Arrange
+        const assertJestSpy = jest.spyOn(AssertJest, "assertJest");
+
+        // Act
+        verifyRealTimers();
+
+        // Assert
+        expect(assertJestSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("should throw when jest.useFakeTimers", () => {
         // Arrange
         jest.useFakeTimers();

--- a/packages/wonder-stuff-testing/src/jest/internal/__tests__/verify-real-timers.test.js
+++ b/packages/wonder-stuff-testing/src/jest/internal/__tests__/verify-real-timers.test.js
@@ -1,0 +1,61 @@
+/* eslint-disable no-console */
+// @flow
+import {verifyRealTimers} from "../verify-real-timers.js";
+
+describe("#verifyRealTimers", () => {
+    it("should throw when jest.useFakeTimers", () => {
+        // Arrange
+        jest.useFakeTimers();
+
+        // Act
+        const underTest = () => verifyRealTimers();
+
+        // Assert
+        expect(underTest).toThrowErrorMatchingInlineSnapshot(
+            `"Cannot use wait() with fake timers. Call jest.useRealTimers() in test case or in a beforeEach."`,
+        );
+    });
+
+    it("should not throw when jest.useRealTimers", () => {
+        // Arrange
+        jest.useRealTimers();
+
+        // Act
+        const underTest = () => verifyRealTimers();
+
+        // Assert
+        expect(underTest).not.toThrow();
+    });
+
+    it("should not invoke a spied on console.warn for the test case", () => {
+        // Arrange
+        jest.useRealTimers();
+        const warnSpy = jest
+            .spyOn(console, "warn")
+            .mockImplementation(() => {});
+
+        // Act
+        verifyRealTimers();
+
+        // Assert
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not override console.warn for the test case", () => {
+        // Arrange
+        jest.useRealTimers();
+        const warnSpy = jest
+            .spyOn(console, "warn")
+            .mockImplementation(() => {});
+
+        // Act
+        console.warn("before");
+        verifyRealTimers();
+        console.warn("after");
+
+        // Assert
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+        expect(warnSpy).toHaveBeenCalledWith("before");
+        expect(warnSpy).toHaveBeenCalledWith("after");
+    });
+});

--- a/packages/wonder-stuff-testing/src/jest/internal/assert-jest.js
+++ b/packages/wonder-stuff-testing/src/jest/internal/assert-jest.js
@@ -1,0 +1,19 @@
+// @flow
+import {KindError} from "@khanacademy/wonder-stuff-core";
+import {Errors} from "../../errors.js";
+import {isRunningInJest} from "./is-running-in-jest.js";
+
+/**
+ * Assert that we're running in jest.
+ */
+export const assertJest = () => {
+    if (!isRunningInJest()) {
+        /**
+         * This file is for use in tests only.
+         */
+        throw new KindError(
+            "Invalid import - for use in tests only",
+            Errors.InvalidUse,
+        );
+    }
+};

--- a/packages/wonder-stuff-testing/src/jest/internal/is-running-in-jest.js
+++ b/packages/wonder-stuff-testing/src/jest/internal/is-running-in-jest.js
@@ -1,0 +1,9 @@
+// @flow
+// istanbul ignore file
+/**
+ * Determine if jest is running or not.
+ *
+ * This is a simple check. We don't export this, but we do use it to do our
+ * own checks, while allowing us to easily test the results of those checks.
+ */
+export const isRunningInJest = (): boolean => typeof jest !== "undefined";

--- a/packages/wonder-stuff-testing/src/jest/internal/unverified-wait.js
+++ b/packages/wonder-stuff-testing/src/jest/internal/unverified-wait.js
@@ -1,0 +1,12 @@
+// @flow
+export const unverifiedWait = (delay: number, count: number): Promise<void> =>
+    new Promise((resolve, reject) => {
+        // eslint-disable-next-line no-restricted-syntax
+        setTimeout(() => {
+            if (count > 1) {
+                resolve(unverifiedWait(delay, count - 1));
+            } else {
+                resolve();
+            }
+        }, delay);
+    });

--- a/packages/wonder-stuff-testing/src/jest/internal/verify-real-timers.js
+++ b/packages/wonder-stuff-testing/src/jest/internal/verify-real-timers.js
@@ -1,0 +1,35 @@
+// @flow
+import {KindError} from "@khanacademy/wonder-stuff-core";
+import {Errors} from "../../errors.js";
+
+/**
+ * Checks that jest is configured to use real timers.
+ */
+export const verifyRealTimers = () => {
+    // Jest may warn if calling timer methods when real timers are used.
+    // We need to silence that, but without impacting folks testing, so we'll be
+    // cheeky. We don't use this to detect the timers though because if they
+    // change this behavior we would silently start just working.
+    // eslint-disable-next-line no-console
+    const oldWarn = console.warn;
+    // $FlowIgnore[cannot-write]
+    console.warn = () => {}; // eslint-disable-line no-console
+
+    try {
+        const timerCount = jest.getTimerCount();
+        // eslint-disable-next-line no-restricted-syntax
+        const timeoutID = setTimeout(() => {}, 0);
+        const newTimerCount = jest.getTimerCount();
+        // eslint-disable-next-line no-restricted-syntax
+        clearTimeout(timeoutID);
+        if (timerCount !== newTimerCount) {
+            throw new KindError(
+                "Cannot use wait() with fake timers. Call jest.useRealTimers() in test case or in a beforeEach.",
+                Errors.InvalidUse,
+            );
+        }
+    } finally {
+        // $FlowIgnore[cannot-write]
+        console.warn = oldWarn; // eslint-disable-line no-console
+    }
+};

--- a/packages/wonder-stuff-testing/src/jest/internal/verify-real-timers.js
+++ b/packages/wonder-stuff-testing/src/jest/internal/verify-real-timers.js
@@ -1,11 +1,14 @@
 // @flow
 import {KindError} from "@khanacademy/wonder-stuff-core";
 import {Errors} from "../../errors.js";
+import {assertJest} from "./assert-jest.js";
 
 /**
  * Checks that jest is configured to use real timers.
  */
 export const verifyRealTimers = () => {
+    assertJest();
+
     // Jest may warn if calling timer methods when real timers are used.
     // We need to silence that, but without impacting folks testing, so we'll be
     // cheeky. We don't use this to detect the timers though because if they

--- a/packages/wonder-stuff-testing/src/jest/isolate-modules.js
+++ b/packages/wonder-stuff-testing/src/jest/isolate-modules.js
@@ -1,4 +1,8 @@
 // @flow
+import {assertJest} from "./internal/assert-jest.js";
+
+assertJest();
+
 /**
  * Isolate imports within a given action using jest.isolateModules.
  *

--- a/packages/wonder-stuff-testing/src/jest/isolate-modules.js
+++ b/packages/wonder-stuff-testing/src/jest/isolate-modules.js
@@ -1,8 +1,6 @@
 // @flow
 import {assertJest} from "./internal/assert-jest.js";
 
-assertJest();
-
 /**
  * Isolate imports within a given action using jest.isolateModules.
  *
@@ -16,12 +14,7 @@ assertJest();
  * jest yet.
  */
 export const isolateModules = <T>(action: () => T): T => {
-    // We can't test this inside jest, since jest will exist and it's not
-    // worth jumping through hoops to make a test work.
-    /* istanbul ignore if */
-    if (typeof jest === "undefined") {
-        throw new Error(`jest is not defined; make sure you are running jest`);
-    }
+    assertJest();
 
     let result = undefined;
     jest.isolateModules(() => {

--- a/packages/wonder-stuff-testing/src/jest/wait.js
+++ b/packages/wonder-stuff-testing/src/jest/wait.js
@@ -1,0 +1,97 @@
+// @flow
+import {KindError} from "@khanacademy/wonder-stuff-core";
+import {Errors} from "../errors.js";
+
+if (typeof jest === "undefined") {
+    /**
+     * This file is for use in tests only.
+     */
+    throw new KindError(
+        "Invalid import - for use in tests only",
+        Errors.InvalidUse,
+    );
+}
+
+/**
+ * Checks that jest is configured to use real timers.
+ */
+const verifyRealTimers = () => {
+    // Jest may warn if calling timer methods when real timers are used.
+    // We need to silence that, but without impacting folks testing, so we'll be
+    // cheeky. We don't use this to detect the timers though because if they
+    // change this behavior we would silently start just working.
+    // eslint-disable-next-line no-console
+    const oldWarn = console.warn;
+    // $FlowIgnore[cannot-write]
+    console.warn = () => {}; // eslint-disable-line no-console
+
+    try {
+        const timerCount = jest.getTimerCount();
+        // eslint-disable-next-line no-restricted-syntax
+        const timeoutID = setTimeout(() => {}, 0);
+        const newTimerCount = jest.getTimerCount();
+        // eslint-disable-next-line no-restricted-syntax
+        clearTimeout(timeoutID);
+        if (timerCount !== newTimerCount) {
+            throw new KindError(
+                "Cannot use wait() with fake timers. Call jest.useRealTimers() in test case or in a beforeEach.",
+                Errors.InvalidUse,
+            );
+        }
+    } finally {
+        // $FlowIgnore[cannot-write]
+        console.warn = oldWarn; // eslint-disable-line no-console
+    }
+};
+
+type WaitOptions = {|
+    /**
+     * The time in milliseconds to wait on each wait.
+     * Defaults to 0. Any number less than 0 will be treated as 0.
+     */
+    delay?: number,
+
+    /**
+     * The number of times to wait.
+     * Defaults to 1. Any number below 1 will be treated as 1.
+     */
+    count?: number,
+|};
+
+const unverifiedWait = (delay: number, count: number) =>
+    new Promise((resolve, reject) => {
+        // eslint-disable-next-line no-restricted-syntax
+        setTimeout(() => {
+            if (count > 1) {
+                resolve(unverifiedWait(delay, count - 1));
+            } else {
+                resolve();
+            }
+        }, delay);
+    });
+
+/**
+ * Wait for the given delay as many times as indicated.
+ *
+ * This will throw if jest.useRealTimers() is not used.
+ */
+export const wait: (options?: WaitOptions) => Promise<void> = ({
+    delay = 0,
+    count = 1,
+} = {}) => {
+    verifyRealTimers();
+
+    const normalizedDelay = delay < 0 ? 0 : delay;
+    const normalizedCount = count < 1 ? 1 : count;
+    return unverifiedWait(normalizedDelay, normalizedCount);
+};
+
+const FRAME_DURATION = 17;
+
+/**
+ * Wait for the given delay.
+ *
+ * This will throw if jest.useRealTimers() is not used.
+ */
+export const waitForAnimationFrame: () => Promise<void> = () =>
+    wait({delay: FRAME_DURATION});

--- a/packages/wonder-stuff-testing/src/jest/wait.js
+++ b/packages/wonder-stuff-testing/src/jest/wait.js
@@ -1,48 +1,9 @@
 // @flow
-import {KindError} from "@khanacademy/wonder-stuff-core";
-import {Errors} from "../errors.js";
+import {verifyRealTimers} from "./internal/verify-real-timers.js";
+import {unverifiedWait} from "./internal/unverified-wait.js";
+import {assertJest} from "./internal/assert-jest.js";
 
-if (typeof jest === "undefined") {
-    /**
-     * This file is for use in tests only.
-     */
-    throw new KindError(
-        "Invalid import - for use in tests only",
-        Errors.InvalidUse,
-    );
-}
-
-/**
- * Checks that jest is configured to use real timers.
- */
-const verifyRealTimers = () => {
-    // Jest may warn if calling timer methods when real timers are used.
-    // We need to silence that, but without impacting folks testing, so we'll be
-    // cheeky. We don't use this to detect the timers though because if they
-    // change this behavior we would silently start just working.
-    // eslint-disable-next-line no-console
-    const oldWarn = console.warn;
-    // $FlowIgnore[cannot-write]
-    console.warn = () => {}; // eslint-disable-line no-console
-
-    try {
-        const timerCount = jest.getTimerCount();
-        // eslint-disable-next-line no-restricted-syntax
-        const timeoutID = setTimeout(() => {}, 0);
-        const newTimerCount = jest.getTimerCount();
-        // eslint-disable-next-line no-restricted-syntax
-        clearTimeout(timeoutID);
-        if (timerCount !== newTimerCount) {
-            throw new KindError(
-                "Cannot use wait() with fake timers. Call jest.useRealTimers() in test case or in a beforeEach.",
-                Errors.InvalidUse,
-            );
-        }
-    } finally {
-        // $FlowIgnore[cannot-write]
-        console.warn = oldWarn; // eslint-disable-line no-console
-    }
-};
+assertJest();
 
 type WaitOptions = {|
     /**
@@ -57,18 +18,6 @@ type WaitOptions = {|
      */
     count?: number,
 |};
-
-const unverifiedWait = (delay: number, count: number) =>
-    new Promise((resolve, reject) => {
-        // eslint-disable-next-line no-restricted-syntax
-        setTimeout(() => {
-            if (count > 1) {
-                resolve(unverifiedWait(delay, count - 1));
-            } else {
-                resolve();
-            }
-        }, delay);
-    });
 
 /**
  * Wait for the given delay as many times as indicated.


### PR DESCRIPTION
## Summary:
This copies the `wait.js` file from webapp so we can start sharing our implementation across projects, but refactors it to get better test coverage and clarity.

Issue: XXX-XXXX

## Test plan:
`yarn test`