### PR TITLE
[fei4349.1.addtestsfornode16] Add 16.x to workflow matrices

### DIFF
--- a/.github/workflows/node-ci-main.yml
+++ b/.github/workflows/node-ci-main.yml
@@ -25,7 +25,7 @@ jobs:
       # which is very helpful.
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -55,7 +55,7 @@ jobs:
         # Use a matrix as it means we get the version info in the job name
         # which is very helpful.
         os: [ubuntu-latest]
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
     - name: Checking out latest commit
       uses: actions/checkout@v2
@@ -137,11 +137,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        node-version: [12.x, 14.x]
+        # We want to include all the versions we support here.
+        node-version: [12.x, 16.x]
         exclude:
-          # The coverage job covers this configuration
+          # And exclude any that our coverage job already includes.
           - os: ubuntu-latest
-            node-version: 14.x
+            node-version: 16.x
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary:
This adds Node 16.x to the workflows and removes 14.x.

We will then want to make sure we target the lerna build to the correct version (which would be the version installed locally - currently 12.x).

Issue: FEI-4349

## Test plan:
See what happens when GitHub runs the workflows.