### PR TITLE
[🔥AUDIT🔥] [fixreleaseactiontriggers] Use personal access token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,12 @@ jobs:
         with:
           publish: yarn publish:ci
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # We use a Personal Access Token here rather than the GITHUB_TOKEN
+          # so that it will trigger our other actions. The token has to be on
+          # the account of someone with appropriate access levels and given the
+          # repo scope. Recommend setting an expiration on the token just so
+          # that it is regularly monitored and updated.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build Slack message


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We want our other workflows to trigger when the Version Packages PR is created. This updates the release workflow that creates that PR to use a personal access token with repo scope instead of the GITHUB_TOKEN so that it will do just that.

I've added a comment in the workflow for folks in case something happens to me or the token expires (currently set to expire after 90 days). That way folks know how to make a new token.

Issue: FEI-4220

## Test plan:
Land this on `main` and see what happens... :fingers_crossed: