### PR TITLE
[🔥AUDIT🔥] [trycloning] Try cloning the repo instead of checkout action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,8 @@ jobs:
       - uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.SSH_NODECI_PRIVATE_KEY }}
-
-      - name: Checkout Repo
-        uses: actions/checkout@master
-        with:
-          # This makes Actions fetch all Git history so that Changesets can
-          # generate changelogs with the correct commits
-          fetch-depth: 0
+      - name: Clone repository
+        run: git clone git@github.com:Khan/wonder-stuff.git .
 
       - name: Setup Node.js 12.x
         uses: actions/setup-node@master


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The force push of the changeset action doesn't retrigger workflows, which is anoying since the use of the personal access token has fixed the PR creation part. I added the SSH agent to try and address this but it still didn't work, so seeing if cloning the repo directly instead of using the checkout action will fix that.

Issue: FEI-4220

## Test plan:
Land on `main` and see what happens.