### PR TITLE
[fei4636.1] Add values() method

### DIFF
--- a/.changeset/warm-terms-care.md
+++ b/.changeset/warm-terms-care.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/wonder-stuff-core": major
+"@khanacademy/wonder-stuff-core": minor
 ---
 
 Add `values` method as strongly-typed alternative to `Object.values`

--- a/.changeset/warm-terms-care.md
+++ b/.changeset/warm-terms-care.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-core": major
+---
+
+Add `values` method as strongly-typed alternative to `Object.values`

--- a/packages/wonder-stuff-core/src/__tests__/values.flowtest.js
+++ b/packages/wonder-stuff-core/src/__tests__/values.flowtest.js
@@ -1,0 +1,36 @@
+// @flow
+import {values} from "../values.js";
+
+{
+    // should type returned array element with union of value types of passed object
+    const obj1 = {
+        a: 1,
+        b: "2",
+        c: [3, 4],
+    };
+    const obj1Values = values(obj1);
+
+    // This works because the variable is typed to all the possible value types.
+    const _: number | string | Array<number> = obj1Values[0];
+
+    // This errors because the variable is only typed to string, but the value
+    // could be a number, string, or array of numbers.
+    // $FlowExpectedError[incompatible-type]
+    const __: string = obj1Values[1];
+}
+
+{
+    // should error if passed object values do not match parameterized type
+    const obj2 = {
+        a: 1,
+        b: "2",
+    };
+
+    // This errors because the return type of values() is not Array<number>
+    // $FlowExpectedError[incompatible-type]
+    const _: Array<number> = values(obj2);
+
+    // This errors because the object does not have values that are all numbers.
+    // $FlowExpectedError[incompatible-call]
+    const __ = values<number>(obj2);
+}

--- a/packages/wonder-stuff-core/src/__tests__/values.flowtest.js
+++ b/packages/wonder-stuff-core/src/__tests__/values.flowtest.js
@@ -20,6 +20,30 @@ import {values} from "../values.js";
 }
 
 {
+    // should work with explicit object-as-map types
+    const map1: {|[string]: number|} = {
+        a: 1,
+        b: 2,
+        c: 3,
+    };
+    const map1Values = values(map1);
+
+    // This works because the variable is typed to number.
+    const _: number = map1Values[0];
+
+    // This errors because the variable is typed to string, and that is not
+    // a number.
+    // $FlowExpectedError[incompatible-type]
+    const __: string = map1Values[1];
+}
+
+{
+    // should return type Array<empty> for empty object
+    const emptyObj = {};
+    const _: Array<empty> = values(emptyObj);
+}
+
+{
     // should error if passed object values do not match parameterized type
     const obj2 = {
         a: 1,

--- a/packages/wonder-stuff-core/src/__tests__/values.test.js
+++ b/packages/wonder-stuff-core/src/__tests__/values.test.js
@@ -1,0 +1,36 @@
+// @flow
+import {values} from "../values.js";
+
+describe("#values", () => {
+    it("should call Object.values with the given object", () => {
+        // Arrange
+        const valuesSpy = jest.spyOn(Object, "values");
+        const obj = {
+            a: 1,
+            b: "2",
+            c: [3, 4],
+        };
+
+        // Act
+        values(obj);
+
+        // Assert
+        expect(valuesSpy).toHaveBeenCalledWith(obj);
+    });
+
+    it("should return the result of Object.values", () => {
+        // Arrange
+        const obj = {
+            a: 1,
+            b: "2",
+            c: [3, 4],
+        };
+        jest.spyOn(Object, "values").mockReturnValue([1, 2, 3]);
+
+        // Act
+        const result = values(obj);
+
+        // Assert
+        expect(result).toEqual([1, 2, 3]);
+    });
+});

--- a/packages/wonder-stuff-core/src/__tests__/values.test.js
+++ b/packages/wonder-stuff-core/src/__tests__/values.test.js
@@ -25,12 +25,12 @@ describe("#values", () => {
             b: "2",
             c: [3, 4],
         };
-        jest.spyOn(Object, "values").mockReturnValue([1, 2, 3]);
+        jest.spyOn(Object, "values").mockReturnValue("THE RESULT");
 
         // Act
         const result = values(obj);
 
         // Assert
-        expect(result).toEqual([1, 2, 3]);
+        expect(result).toEqual("THE RESULT");
     });
 });

--- a/packages/wonder-stuff-core/src/index.js
+++ b/packages/wonder-stuff-core/src/index.js
@@ -1,5 +1,6 @@
 // @flow
 export {clone} from "./clone.js";
+export {values} from "./values.js";
 export {Errors} from "./errors.js";
 export {errorsFromError, Order} from "./errors-from-error.js";
 export {getKindFromError} from "./get-kind-from-error.js";

--- a/packages/wonder-stuff-core/src/values.js
+++ b/packages/wonder-stuff-core/src/values.js
@@ -1,10 +1,10 @@
 // @flow
 /**
- * Return an array of the enumerable properties of an object.
+ * Return an array of the enumerable property values of an object.
  *
  * @param {$ReadOnly<{[mixed]: V}>} obj The object for which the values are
  * to be returned.
- * @returns {Array<V>} An array of the enumerable properties of an object.
+ * @returns {Array<V>} An array of the enumerable property values of the object.
  */
 export function values<V>(obj: $ReadOnly<{|[mixed]: V|}>): Array<V> {
     // This is a deliberate cast through any.

--- a/packages/wonder-stuff-core/src/values.js
+++ b/packages/wonder-stuff-core/src/values.js
@@ -1,0 +1,14 @@
+// @flow
+/**
+ * Return an array of the enumerable properties of an object.
+ *
+ * @param {$ReadOnly<{[mixed]: V}>} obj The object for which the values are
+ * to be returned.
+ * @returns {Array<V>} An array of the enumerable properties of an object.
+ */
+export function values<V>(obj: $ReadOnly<{|[mixed]: V|}>): Array<V> {
+    // This is a deliberate cast through any.
+    // Object.values returns Array<mixed> and we want to return Array<V>.
+    // $FlowIgnore[unclear-type]
+    return (Object.values(obj): Array<any>);
+}


### PR DESCRIPTION
## Summary:
This adds a version of `values()` that provides strong typing of the returned array, rather than `Array<mixed>` as `Object.values()` would.

Issue: FEI-4636

## Test plan:
`yarn test`
`yarn flow`