### PR TITLE
[fei4636.3] Add entries() method

### DIFF
--- a/.changeset/and-this-too.md
+++ b/.changeset/and-this-too.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-core": major
+---
+
+Add `entries` method as strongly-typed alternative to `Object.entries`

--- a/.changeset/and-this-too.md
+++ b/.changeset/and-this-too.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/wonder-stuff-core": major
+"@khanacademy/wonder-stuff-core": minor
 ---
 
 Add `entries` method as strongly-typed alternative to `Object.entries`

--- a/packages/wonder-stuff-core/src/__tests__/entries.flowtest.js
+++ b/packages/wonder-stuff-core/src/__tests__/entries.flowtest.js
@@ -1,0 +1,53 @@
+// @flow
+import {entries} from "../entries.js";
+
+{
+    // should type returned array element as tuples of keys as string subtype
+    const obj1 = {
+        a: 1,
+        b: "2",
+        c: [3, 4],
+    };
+
+    const entries1 = entries(obj1);
+
+    // This works because the keys are all strings
+    const [_]: [string, mixed] = entries1[0];
+}
+
+{
+    // should type returned array element as tuples supertype of keys
+    const obj2 = {
+        a: 1,
+        b: "2",
+        c: [3, 4],
+    };
+    const entries2 = entries(obj2);
+
+    // This works because the returned tuple type is of a supertype of all key
+    // names and the value type (which we don't care about for this flow check).
+    const [_]: ["a" | "b" | "c", mixed] = entries2[0];
+
+    // This errors because we try to get a key of only one type.
+    // $FlowExpectedError[incompatible-type]
+    const [__]: ["a", mixed] = entries2[0];
+}
+
+{
+    // should type returned array element as tuples of values as supertype
+    const obj1 = {
+        a: 1,
+        b: "2",
+        c: [3, 4],
+    };
+
+    const entries1 = entries(obj1);
+
+    // This works because the keys are all strings, and the values are a
+    // supertype of all the value types in the object.
+    const [_, __]: [string, number | string | Array<number>] = entries1[0];
+
+    // This errors because not all values are a number.
+    // $FlowExpectedError[incompatible-type]
+    const [___, ____]: [string, number] = entries1[0];
+}

--- a/packages/wonder-stuff-core/src/__tests__/entries.test.js
+++ b/packages/wonder-stuff-core/src/__tests__/entries.test.js
@@ -1,0 +1,44 @@
+// @flow
+import {entries} from "../entries.js";
+
+describe("#entries", () => {
+    it("should call Object.entries with the given object", () => {
+        // Arrange
+        const entriesSpy = jest.spyOn(Object, "entries");
+        const obj = {
+            a: 1,
+            b: "2",
+            c: [3, 4],
+        };
+
+        // Act
+        entries(obj);
+
+        // Assert
+        expect(entriesSpy).toHaveBeenCalledWith(obj);
+    });
+
+    it("should return the result of Object.entries", () => {
+        // Arrange
+        const obj = {
+            a: 1,
+            b: "2",
+            c: [3, 4],
+        };
+        jest.spyOn(Object, "entries").mockReturnValueOnce([
+            ["e", 1],
+            ["f", 2],
+            ["g", 3],
+        ]);
+
+        // Act
+        const result = entries(obj);
+
+        // Assert
+        expect(result).toEqual([
+            ["e", 1],
+            ["f", 2],
+            ["g", 3],
+        ]);
+    });
+});

--- a/packages/wonder-stuff-core/src/entries.js
+++ b/packages/wonder-stuff-core/src/entries.js
@@ -1,5 +1,12 @@
 // @flow
-export function entries<K, V>(obj: {[K]: V}): Array<[K, V]> {
+/**
+ * Return an array of key/value tuples for an object.
+ *
+ * @param {$ReadOnly<{[K]: V}>} obj The object for which the values are
+ * to be returned.
+ * @returns {Array<[K, V]>} An array of key/value tuples for the object.
+ */
+export function entries<K, V>(obj: $ReadOnly<{[K]: V}>): Array<[K, V]> {
     // This cast is deliberate as Object.entries is typed to return
     // Array<[string, mixed]>, but we want to return Array<[K, V]>.
     // $FlowIgnore[unclear-type]

--- a/packages/wonder-stuff-core/src/entries.js
+++ b/packages/wonder-stuff-core/src/entries.js
@@ -1,0 +1,7 @@
+// @flow
+export function entries<K, V>(obj: {[K]: V}): Array<[K, V]> {
+    // This cast is deliberate as Object.entries is typed to return
+    // Array<[string, mixed]>, but we want to return Array<[K, V]>.
+    // $FlowIgnore[unclear-type]
+    return (Object.entries(obj): any);
+}

--- a/packages/wonder-stuff-core/src/index.js
+++ b/packages/wonder-stuff-core/src/index.js
@@ -1,5 +1,6 @@
 // @flow
 export {clone} from "./clone.js";
+export {entries} from "./entries.js";
 export {keys} from "./keys.js";
 export {values} from "./values.js";
 export {Errors} from "./errors.js";


### PR DESCRIPTION
## Summary:
This adds a strongly typed `entries()` method to use in place of `Object.entries()`

Issue: FEI-4636

## Test plan:
`yarn test`
`yarn flow`