### PR TITLE
[objasinterface] Make sure that keys/values/entries are typed to work against class instances too

### DIFF
--- a/.changeset/nice-shirts-switch.md
+++ b/.changeset/nice-shirts-switch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-core": patch
+---
+
+Broaden typing for keys/values/entries methods

--- a/packages/wonder-stuff-core/src/__tests__/entries.flowtest.js
+++ b/packages/wonder-stuff-core/src/__tests__/entries.flowtest.js
@@ -51,3 +51,15 @@ import {entries} from "../entries.js";
     // $FlowExpectedError[incompatible-type]
     const [___, ____]: [string, number] = entries1[0];
 }
+
+{
+    // should work with class instances
+    class Foo {
+        a: string;
+        b: string;
+    }
+    const foo = new Foo();
+
+    // This should not be erroring.
+    const _ = entries(foo);
+}

--- a/packages/wonder-stuff-core/src/__tests__/keys.flowtest.js
+++ b/packages/wonder-stuff-core/src/__tests__/keys.flowtest.js
@@ -43,3 +43,15 @@ import {keys} from "../keys.js";
     // This should not be erroring.
     const _ = keys(obj3);
 }
+
+{
+    // should work with class instances
+    class Foo {
+        a: string;
+        b: string;
+    }
+    const foo = new Foo();
+
+    // This should not be erroring.
+    const _ = keys(foo);
+}

--- a/packages/wonder-stuff-core/src/__tests__/values.flowtest.js
+++ b/packages/wonder-stuff-core/src/__tests__/values.flowtest.js
@@ -58,3 +58,15 @@ import {values} from "../values.js";
     // $FlowExpectedError[incompatible-call]
     const __ = values<number>(obj2);
 }
+
+{
+    // should work with class instances
+    class Foo {
+        a: string;
+        b: string;
+    }
+    const foo = new Foo();
+
+    // This should not be erroring.
+    const _ = values(foo);
+}

--- a/packages/wonder-stuff-core/src/entries.js
+++ b/packages/wonder-stuff-core/src/entries.js
@@ -2,11 +2,13 @@
 /**
  * Return an array of key/value tuples for an object.
  *
- * @param {$ReadOnly<{[K]: V}>} obj The object for which the values are
+ * @param {$ReadOnly<interface {[K]: V}>} obj The object for which the values are
  * to be returned.
  * @returns {Array<[K, V]>} An array of key/value tuples for the object.
  */
-export function entries<K, V>(obj: $ReadOnly<{[K]: V}>): Array<[K, V]> {
+export function entries<K, V>(
+    obj: $ReadOnly<interface {[K]: V}>,
+): Array<[K, V]> {
     // This cast is deliberate as Object.entries is typed to return
     // Array<[string, mixed]>, but we want to return Array<[K, V]>.
     // $FlowIgnore[unclear-type]

--- a/packages/wonder-stuff-core/src/keys.js
+++ b/packages/wonder-stuff-core/src/keys.js
@@ -2,10 +2,12 @@
 /**
  * Return an array of the enumerable keys of an object.
  *
- * @param {$ReadOnly<{[string]: mixed}>} obj The object for which the values are
+ * @param {$ReadOnly<interface {[string]: mixed}>} obj The object for which the values are
  * to be returned.
  * @returns {Array<$Keys<O>>} An array of the enumerable keys of an object.
  */
-export function keys<O: {[string]: mixed}>(obj: $ReadOnly<O>): Array<$Keys<O>> {
+export function keys<O: interface {[string]: mixed}>(
+    obj: $ReadOnly<O>,
+): Array<$Keys<O>> {
     return Object.keys(obj);
 }

--- a/packages/wonder-stuff-core/src/values.js
+++ b/packages/wonder-stuff-core/src/values.js
@@ -2,11 +2,11 @@
 /**
  * Return an array of the enumerable property values of an object.
  *
- * @param {$ReadOnly<{[mixed]: V}>} obj The object for which the values are
+ * @param {$ReadOnly<interface {[mixed]: V}>} obj The object for which the values are
  * to be returned.
  * @returns {Array<V>} An array of the enumerable property values of the object.
  */
-export function values<V>(obj: $ReadOnly<{|[mixed]: V|}>): Array<V> {
+export function values<V>(obj: $ReadOnly<interface {[mixed]: V}>): Array<V> {
     // This is a deliberate cast through any.
     // Object.values returns Array<mixed> and we want to return Array<V>.
     // $FlowIgnore[unclear-type]


### PR DESCRIPTION
## Summary:
Noticed in webapp that some uses are passing a class instance and we should support that. Flow error indicated using an interface rather than object type so that it would match both objects and class instances. So this does that.

Issue: XXX-XXXX

## Test plan:
`yarn flow`