### PR TITLE
TS Prep 2: Replace 'enum's with object literals

### DIFF
--- a/packages/wonder-stuff-server-google/src/add-app-engine-middleware.js
+++ b/packages/wonder-stuff-server-google/src/add-app-engine-middleware.js
@@ -11,7 +11,7 @@ import {makeAppEngineRequestIDMiddleware} from "./middleware/make-app-engine-req
  */
 export async function addAppEngineMiddleware<TReq: $Request, TRes: $Response>(
     app: $Application<TReq, TRes>,
-    mode: Runtime,
+    mode: $Values<typeof Runtime>,
     logger: Logger,
 ): Promise<$Application<TReq, TRes>> {
     const middlewareApp = express<TReq, TRes>();

--- a/packages/wonder-stuff-server-google/src/setup-integrations.js
+++ b/packages/wonder-stuff-server-google/src/setup-integrations.js
@@ -8,7 +8,7 @@ import type {GoogleCloudIntegrations} from "./types";
  * These integrations help debug production services.
  */
 export const setupIntegrations = async (
-    mode: Runtime,
+    mode: $Values<typeof Runtime>,
     {debugAgent, profiler}: GoogleCloudIntegrations = {
         debugAgent: false,
         profiler: false,

--- a/packages/wonder-stuff-server/src/__tests__/start-server.test.js
+++ b/packages/wonder-stuff-server/src/__tests__/start-server.test.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Express from "express";
+import {values} from "@khanacademy/wonder-stuff-core";
 import * as RootLogger from "../root-logger";
 import * as DefaultRequestLogging from "../middleware/default-request-logging";
 import * as DefaultErrorLogging from "../middleware/default-error-logging";
@@ -48,7 +49,7 @@ describe("#start-server", () => {
         expect(setRootLoggerSpy).toHaveBeenCalledWith(logger);
     });
 
-    it.each(Array.from(Runtime.members()))(
+    it.each(Array.from(values(Runtime)))(
         "should import heapdumps if allowHeapDumps is true",
         async (mode) => {
             // Arrange

--- a/packages/wonder-stuff-server/src/get-logging-transport.js
+++ b/packages/wonder-stuff-server/src/get-logging-transport.js
@@ -28,7 +28,7 @@ const devFormatter = ({level, message, ...metadata}: Info): string => {
 /**
  * Build the formatters to give us some nice dev output.
  */
-const getFormatters = (mode: Runtime): Format => {
+const getFormatters = (mode: $Values<typeof Runtime>): Format => {
     const formatters: Array<Format> = [
         winston.format.splat(), // Allows for %s style substitutions
     ];
@@ -49,7 +49,7 @@ const getFormatters = (mode: Runtime): Format => {
  * Gets the logging transport for the given mode.
  */
 export const getLoggingTransport = (
-    mode: Runtime,
+    mode: $Values<typeof Runtime>,
     logLevel: LogLevel,
 ): Transport => {
     switch (mode) {

--- a/packages/wonder-stuff-server/src/get-runtime-mode.js
+++ b/packages/wonder-stuff-server/src/get-runtime-mode.js
@@ -13,7 +13,9 @@ import {Runtime} from "./types";
  *
  * @returns {Runtime} The runtime mode of production, development, or test.
  */
-export const getRuntimeMode = (defaultMode: Runtime): Runtime => {
+export const getRuntimeMode = (
+    defaultMode: $Values<typeof Runtime>,
+): $Values<typeof Runtime> => {
     switch (process.env.NODE_ENV) {
         case "test":
             return Runtime.Test;

--- a/packages/wonder-stuff-server/src/types.js
+++ b/packages/wonder-stuff-server/src/types.js
@@ -27,13 +27,9 @@ export type Logger = WinstonLogger<NpmLogLevels>;
  * The runtime modes that a gateway can run under.
  */
 export const Runtime = {
-    // TODO(somewhatabstract, FEI-4172): Update eslint-plugin-flowtype when
-    // they've fixed https://github.com/gajus/eslint-plugin-flowtype/issues/502
-    /* eslint-disable no-undef */
     Production: ("production": "production"),
     Development: ("development": "development"),
     Test: ("test": "test"),
-    /* eslint-enable no-undef */
 };
 
 /**

--- a/packages/wonder-stuff-server/src/types.js
+++ b/packages/wonder-stuff-server/src/types.js
@@ -26,15 +26,15 @@ export type Logger = WinstonLogger<NpmLogLevels>;
 /**
  * The runtime modes that a gateway can run under.
  */
-export enum Runtime {
+export const Runtime = {
     // TODO(somewhatabstract, FEI-4172): Update eslint-plugin-flowtype when
     // they've fixed https://github.com/gajus/eslint-plugin-flowtype/issues/502
     /* eslint-disable no-undef */
-    Production = "production",
-    Development = "development",
-    Test = "test",
+    Production: ("production": "production"),
+    Development: ("development": "development"),
+    Test: ("test": "test"),
     /* eslint-enable no-undef */
-}
+};
 
 /**
  * Options to configure logging.
@@ -43,7 +43,7 @@ export type LoggingOptions = {
     /**
      * The runtime mode.
      */
-    mode: Runtime,
+    mode: $Values<typeof Runtime>,
 
     /**
      * Log only if the level of a logged entry is less than or equal to this
@@ -91,7 +91,7 @@ export type ServerOptions = {
     /**
      * What runtime mode the server is running under.
      */
-    +mode: Runtime,
+    +mode: $Values<typeof Runtime>,
 
     /**
      * Optional value in milliseconds for keepalive timeout of the server.


### PR DESCRIPTION
## Summary:
This is an experimental PR is to prep the repo for migration to TS.  After migration I'm going to be trying different things to allow us to continue using wonder-stuff as a dep in Flow projects.

The reason for remove enums is the migration tool doesn't understand them and won't convert any files containing an enum.

Issue: FEI-4926

## Test plan:
- yarn flow