### PR TITLE
FEI-4957.10: Re-add entries, keys, and values wrappers

### DIFF
--- a/.changeset/long-pears-laugh.md
+++ b/.changeset/long-pears-laugh.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-core": minor
+---
+
+Re-add entries, keys, and values wrappers

--- a/config/jest/test.config.js
+++ b/config/jest/test.config.js
@@ -26,7 +26,7 @@ module.exports = {
         "packages/**/*.ts",
         "!packages/**/types.ts",
         "!packages/**/src/**/index.ts",
-        "!packages/**/*.flowtest.ts",
+        "!packages/**/*.typestest.ts",
         "!packages/**/dist/**/*.ts",
         "!<rootDir>/node_modules/",
         "!packages/**/node_modules/",

--- a/packages/eslint-config-khan/index.js
+++ b/packages/eslint-config-khan/index.js
@@ -62,8 +62,10 @@ module.exports = {
         "no-unreachable": ERROR,
         "no-unused-expressions": ERROR,
         "no-unused-vars": OFF,
-        "@typescript-eslint/no-unused-vars": WARN,
-        //  {args: "none", varsIgnorePattern: "^_*$"}],
+        "@typescript-eslint/no-unused-vars": [
+            ERROR,
+            {args: "none", varsIgnorePattern: "^_*$"},
+        ],
         "no-useless-call": ERROR,
         "no-var": ERROR,
         "no-with": ERROR,

--- a/packages/wonder-stuff-core/src/__tests__/entries.test.ts
+++ b/packages/wonder-stuff-core/src/__tests__/entries.test.ts
@@ -1,0 +1,44 @@
+// @flow
+import {entries} from "../entries";
+
+describe("#entries", () => {
+    it("should call Object.entries with the given object", () => {
+        // Arrange
+        const entriesSpy = jest.spyOn(Object, "entries");
+        const obj = {
+            a: 1,
+            b: "2",
+            c: [3, 4],
+        };
+
+        // Act
+        entries(obj);
+
+        // Assert
+        expect(entriesSpy).toHaveBeenCalledWith(obj);
+    });
+
+    it("should return the result of Object.entries", () => {
+        // Arrange
+        const obj = {
+            a: 1,
+            b: "2",
+            c: [3, 4],
+        };
+        jest.spyOn(Object, "entries").mockReturnValueOnce([
+            ["e", 1],
+            ["f", 2],
+            ["g", 3],
+        ]);
+
+        // Act
+        const result = entries(obj);
+
+        // Assert
+        expect(result).toEqual([
+            ["e", 1],
+            ["f", 2],
+            ["g", 3],
+        ]);
+    });
+});

--- a/packages/wonder-stuff-core/src/__tests__/entries.typestest.ts
+++ b/packages/wonder-stuff-core/src/__tests__/entries.typestest.ts
@@ -1,0 +1,69 @@
+import {entries} from "../entries";
+
+{
+    // should type returned array element as tuples of keys as string subtype
+    const obj1 = {
+        a: 1,
+        b: "2",
+        c: [3, 4],
+    };
+
+    const entries1 = entries(obj1);
+
+    // This works because the keys are all strings
+    const [_]: [string, unknown] = entries1[0];
+}
+
+{
+    // should type returned array element as tuples supertype of keys
+    const obj2 = {
+        a: 1,
+        b: "2",
+        c: [3, 4],
+    } as const;
+    const entries2 = entries(obj2);
+
+    // It would be nice if this worked, but TypeScript's library definition
+    // defines the first item in the tuples returned by Object.entries() to
+    // be `string`s.
+    // @ts-expect-error: "a" | "b" | "c" is not assignable to string
+    const [_]: ["a" | "b" | "c", unknown] = entries2[0];
+
+    // This errors because we try to get a key of only one type.
+    // @ts-expect-error: "a" is not assignable to string
+    const [__]: ["a", unknown] = entries2[0];
+}
+
+{
+    // should type returned array element as tuples of values as supertype
+    const obj1 = {
+        a: 1,
+        b: "2",
+        c: [3, 4],
+    };
+
+    const entries1 = entries(obj1);
+
+    // This works because the keys are all strings, and the values are a
+    // supertype of all the value types in the object.
+    const [_, __]: [string, number | string | Array<number>] = entries1[0];
+
+    // @ts-expect-error: This errors because not all values are a number.
+    const [___, ____]: [string, number] = entries1[0];
+}
+
+{
+    // should work with class instances
+    class Foo {
+        a: string;
+        b: string;
+        constructor(a: string, b: string) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+    const foo = new Foo("hello", "world");
+
+    // This should not be erroring.
+    const _ = entries(foo);
+}

--- a/packages/wonder-stuff-core/src/__tests__/keys.test.ts
+++ b/packages/wonder-stuff-core/src/__tests__/keys.test.ts
@@ -1,0 +1,35 @@
+import {keys} from "../keys";
+
+describe("#keys", () => {
+    it("should call Object.keys with the given object", () => {
+        // Arrange
+        const keysSpy = jest.spyOn(Object, "keys");
+        const obj = {
+            a: 1,
+            b: "2",
+            c: [3, 4],
+        };
+
+        // Act
+        keys(obj);
+
+        // Assert
+        expect(keysSpy).toHaveBeenCalledWith(obj);
+    });
+
+    it("should return the result of Object.keys", () => {
+        // Arrange
+        const obj = {
+            a: 1,
+            b: "2",
+            c: [3, 4],
+        };
+        jest.spyOn(Object, "keys").mockReturnValueOnce(["THE RESULT"]);
+
+        // Act
+        const result = keys(obj);
+
+        // Assert
+        expect(result).toEqual(["THE RESULT"]);
+    });
+});

--- a/packages/wonder-stuff-core/src/__tests__/keys.typestest.ts
+++ b/packages/wonder-stuff-core/src/__tests__/keys.typestest.ts
@@ -1,0 +1,57 @@
+import {keys} from "../keys";
+
+{
+    // should type returned array element as subtype of string
+    const obj1 = {
+        a: 1,
+        b: "2",
+    };
+
+    const keys1 = keys(obj1);
+    const _: string = keys1[0];
+}
+
+{
+    // should type returned array element as supertype of keys
+    const obj2 = {
+        a: 1,
+        b: "2",
+        c: [3, 4],
+    } as const;
+
+    // It would be nice if this worked, but TypeScript's library definition
+    // defines the return type of Object.keys() to be Array<string>.
+    const keys2bad = keys(obj2);
+    // @ts-expect-error: string is not assignable to "a" | "b" | "c"
+    const _: "a" | "b" | "c" = keys2bad[0];
+
+    // @ts-expect-error: This errors because we try to get a key of only one type.
+    const __: "a" = keys2bad[0];
+}
+
+{
+    // should work with more specific object types
+    const obj3: Record<string, string> = {
+        a: "1",
+        b: "2",
+    };
+
+    // This should not be erroring.
+    const _ = keys(obj3);
+}
+
+{
+    // should work with class instances
+    class Foo {
+        a: string;
+        b: string;
+        constructor(a: string, b: string) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+    const foo = new Foo("hello", "world");
+
+    // This should not be erroring.
+    const _ = keys(foo);
+}

--- a/packages/wonder-stuff-core/src/__tests__/values.test.ts
+++ b/packages/wonder-stuff-core/src/__tests__/values.test.ts
@@ -1,0 +1,35 @@
+import {values} from "../values";
+
+describe("#values", () => {
+    it("should call Object.values with the given object", () => {
+        // Arrange
+        const valuesSpy = jest.spyOn(Object, "values");
+        const obj = {
+            a: 1,
+            b: "2",
+            c: [3, 4],
+        };
+
+        // Act
+        values(obj);
+
+        // Assert
+        expect(valuesSpy).toHaveBeenCalledWith(obj);
+    });
+
+    it("should return the result of Object.values", () => {
+        // Arrange
+        const obj = {
+            a: 1,
+            b: "2",
+            c: [3, 4],
+        };
+        jest.spyOn(Object, "values").mockReturnValue(["THE RESULT"]);
+
+        // Act
+        const result = values(obj);
+
+        // Assert
+        expect(result).toEqual(["THE RESULT"]);
+    });
+});

--- a/packages/wonder-stuff-core/src/__tests__/values.typestest.ts
+++ b/packages/wonder-stuff-core/src/__tests__/values.typestest.ts
@@ -1,0 +1,71 @@
+import {values} from "../values";
+
+{
+    // should type returned array element with union of value types of passed object
+    const obj1 = {
+        a: 1,
+        b: "2",
+        c: [3, 4],
+    };
+    const obj1Values = values(obj1);
+
+    // This works because the variable is typed to all the possible value types.
+    const _: number | string | Array<number> = obj1Values[0];
+
+    // @ts-expect-error: This errors because the variable is only typed to string, but
+    // the value could be a number, string, or array of numbers.
+    const __: string = obj1Values[1];
+}
+
+{
+    // should work with explicit object-as-map types
+    const map1: {[key: string]: number} = {
+        a: 1,
+        b: 2,
+        c: 3,
+    };
+    const map1Values = values(map1);
+
+    // This works because the variable is typed to number.
+    const _: number = map1Values[0];
+
+    // @ts-expect-error: This errors because the variable is typed to string, and that
+    // is not a number.
+    const __: string = map1Values[1];
+}
+
+{
+    // should return type Array<empty> for empty object
+    const emptyObj = {};
+    const _: Array<never> = values(emptyObj);
+}
+
+{
+    // should error if passed object values do not match parameterized type
+    const obj2 = {
+        a: 1,
+        b: "2",
+    };
+
+    // @ts-expect-error: This errors because the return type of values() is not Array<number>
+    const _: Array<number> = values(obj2);
+
+    // @ts-expect-error: This errors because the object does not have values that are all numbers.
+    const __ = values<number>(obj2);
+}
+
+{
+    // should work with class instances
+    class Foo {
+        a: string;
+        b: string;
+        constructor(a: string, b: string) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+    const foo = new Foo("hello", "world");
+
+    // This should not be erroring.
+    const _ = values(foo);
+}

--- a/packages/wonder-stuff-core/src/entries.ts
+++ b/packages/wonder-stuff-core/src/entries.ts
@@ -1,0 +1,19 @@
+/**
+ * Return an array of key/value tuples for an object.
+ *
+ * @param {{[s: string]: T}} obj The object for which the values are
+ * to be returned.
+ * @returns {Array<[string, T]>} An array of key/value tuples for the object.
+ */
+// NOTE(kevinb): This type was copied from TypeScript's library definitions.
+export const entries: {
+    <T>(
+        obj:
+            | {
+                  [s: string]: T;
+              }
+            | ArrayLike<T>,
+    ): [string, T][];
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    (obj: {}): [string, any][];
+} = (obj: any) => Object.entries(obj);

--- a/packages/wonder-stuff-core/src/keys.ts
+++ b/packages/wonder-stuff-core/src/keys.ts
@@ -1,0 +1,12 @@
+/**
+ * Return an array of the enumerable keys of an object.
+ *
+ * @param {$ReadOnly<interface {[string]: mixed}>} obj The object for which the values are
+ * to be returned.
+ * @returns {Array<$Keys<O>>} An array of the enumerable keys of an object.
+ */
+// NOTE(kevinb): This type was copied from TypeScript's library definitions.
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function keys(obj: {}): string[] {
+    return Object.keys(obj);
+}

--- a/packages/wonder-stuff-core/src/values.ts
+++ b/packages/wonder-stuff-core/src/values.ts
@@ -1,0 +1,19 @@
+/**
+ * Return an array of the enumerable property values of an object.
+ *
+ * @param {$ReadOnly<interface {[mixed]: V}>} obj The object for which the values are
+ * to be returned.
+ * @returns {Array<V>} An array of the enumerable property values of the object.
+ */
+// NOTE(kevinb): This type was copied from TypeScript's library definitions.
+export const values: {
+    <T>(
+        obj:
+            | {
+                  [s: string]: T;
+              }
+            | ArrayLike<T>,
+    ): T[];
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    (obj: {}): any[];
+} = (obj: any) => Object.values(obj);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,7 +1505,7 @@
     "@types/node" "*"
     jest-mock "^29.4.3"
 
-"@jest/expect-utils@^29.4.3":
+"@jest/expect-utils@^29.4.2", "@jest/expect-utils@^29.4.3":
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.4.3.tgz#95ce4df62952f071bcd618225ac7c47eaa81431e"
   integrity sha512-/6JWbkxHOP8EoS8jeeTd9dTfc9Uawi+43oLKHfp6zzux3U2hqOOVnV3ai4RpDYHOccL6g+5nrxpoc8DmJxtXVQ==
@@ -5281,7 +5281,7 @@ jest-get-type@^29.0.0, jest-get-type@^29.2.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.2.0.tgz#726646f927ef61d583a3b3adb1ab13f3a5036408"
   integrity sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==
 
-jest-get-type@^29.4.3:
+jest-get-type@^29.4.2, jest-get-type@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.4.3.tgz#1ab7a5207c995161100b5187159ca82dd48b3dd5"
   integrity sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==
@@ -5313,7 +5313,7 @@ jest-leak-detector@^29.4.3:
     jest-get-type "^29.4.3"
     pretty-format "^29.4.3"
 
-jest-matcher-utils@^29.4.3:
+jest-matcher-utils@^29.4.2, jest-matcher-utils@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.4.3.tgz#ea68ebc0568aebea4c4213b99f169ff786df96a0"
   integrity sha512-TTciiXEONycZ03h6R6pYiZlSkvYgT0l8aa49z/DLSGYjex4orMUcafuLXYyyEDWB1RKglq00jzwY00Ei7yFNVg==
@@ -5323,7 +5323,7 @@ jest-matcher-utils@^29.4.3:
     jest-get-type "^29.4.3"
     pretty-format "^29.4.3"
 
-jest-message-util@^29.4.3:
+jest-message-util@^29.4.2, jest-message-util@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.4.3.tgz#65b5280c0fdc9419503b49d4f48d4999d481cb5b"
   integrity sha512-1Y8Zd4ZCN7o/QnWdMmT76If8LuDv23Z1DRovBj/vcSFNlGCJGoO8D1nJDw1AdyAGUk0myDLFGN5RbNeJyCRGCw==
@@ -5465,7 +5465,7 @@ jest-snapshot@^29.4.3:
     pretty-format "^29.4.3"
     semver "^7.3.5"
 
-jest-util@^29.4.3:
+jest-util@^29.4.2, jest-util@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.4.3.tgz#851a148e23fc2b633c55f6dad2e45d7f4579f496"
   integrity sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==


### PR DESCRIPTION
## Summary:
I did some more thinking about this and updating all of our uses of these wrappers in webapp is going to be a pain. It'll be easier to drop the wrappers after the conversion. I was able to add types for the overloads that TypeScript provides. It'll be interesting to see how well these translate to Flow.  I've also update the eslint config to ignore variables that are just underscores which is what we had originally.

Issue: FEI-4957

## Test plan:
- yarn lint
- yarn build:types
- yarn build:flowtypes
- copy/paste the types for entries, keys, and values into the Flow playground and do some spot check testing with them (it's okay if their behavior isn't exactly the same as the old Flow types for these wrappers)