### PR TITLE
Make core a real dep of server

### DIFF
--- a/.changeset/beige-otters-exist.md
+++ b/.changeset/beige-otters-exist.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-server": patch
+---
+
+Make wonder-stuff-core a real dependency instead of a peer dependency

--- a/packages/wonder-stuff-server/package.json
+++ b/packages/wonder-stuff-server/package.json
@@ -14,13 +14,15 @@
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },
+    "dependencies": {
+        "@khanacademy/wonder-stuff-core": "^1.0.2"
+    },
     "devDependencies": {
         "ws-dev-build-settings": "^0.0.5"
     },
     "author": "",
     "license": "MIT",
     "peerDependencies": {
-        "@khanacademy/wonder-stuff-core": "^1.0.2",
         "express": "^4.17.2",
         "express-winston": "^4.2.0",
         "winston": "^3.4.0"


### PR DESCRIPTION
## Summary:
When reviewing the changes in #536, I noticed that some packages were being bumped a major version even though none of the changeset .md files specified such changes.  It appears this is happening due changeset treating peer deps differently from regular deps.  This PR fixes the issue by make wonder-stuff-core a regular dependency of wonder-stuff-server.

Issue: None

## Test plan:
- land this PR and see #536 update appropriately