### PR TITLE
Convert more peer deps into real deps

### DIFF
--- a/.changeset/dull-fishes-relate.md
+++ b/.changeset/dull-fishes-relate.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-stuff-server-google": patch
+"@khanacademy/wonder-stuff-testing": patch
+---
+
+Convert wonder-stuff-\* peer dependencies to be real dependencies.

--- a/packages/wonder-stuff-server-google/package.json
+++ b/packages/wonder-stuff-server-google/package.json
@@ -14,6 +14,10 @@
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },
+    "dependencies": {
+        "@khanacademy/wonder-stuff-core": "^1.0.2",
+        "@khanacademy/wonder-stuff-server": "^2.0.2"
+    },
     "devDependencies": {
         "ws-dev-build-settings": "^0.0.5"
     },
@@ -24,8 +28,6 @@
         "@google-cloud/logging-winston": "^4.1.1",
         "@google-cloud/profiler": "^4.1.7",
         "@google-cloud/trace-agent": "^5.1.6",
-        "@khanacademy/wonder-stuff-core": "^1.0.2",
-        "@khanacademy/wonder-stuff-server": "^2.0.2",
         "express": "^4.17.2",
         "express-winston": "^4.2.0",
         "winston": "^3.4.0"

--- a/packages/wonder-stuff-testing/package.json
+++ b/packages/wonder-stuff-testing/package.json
@@ -14,11 +14,11 @@
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },
+    "dependencies": {
+        "@khanacademy/wonder-stuff-core": "^1.0.2"
+    },
     "devDependencies": {
         "ws-dev-build-settings": "^0.0.5"
-    },
-    "peerDependencies": {
-        "@khanacademy/wonder-stuff-core": "^1.0.2"
     },
     "browser": {
         "dist/es/index.js": "./dist/es/index.browser.js",


### PR DESCRIPTION
## Summary:
I updated wonder-stuff-server's deps in #544, but missing that wonder-stuff-testing and wonder-stuff-server-google are affected by the same issue.  This PR fixes them as well.

Issue: None

## Test plan:
- Land and wait for #536, see that wonder-stuff-server-google and wonder-stuff-testing are bumped by a minor version