### PR TITLE
[🔥AUDIT🔥] Update wonder-stuff-core to export 'entries', 'keys', and 'values' wrapper functions

### DIFF
--- a/.changeset/sweet-lemons-argue.md
+++ b/.changeset/sweet-lemons-argue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-core": minor
+---
+
+Export 'entries', 'keys', and 'values' wrappers

--- a/packages/wonder-stuff-core/src/index.ts
+++ b/packages/wonder-stuff-core/src/index.ts
@@ -1,10 +1,13 @@
 export {clone} from "./clone";
+export {entries} from "./entries";
 export {Errors} from "./errors";
 export {errorsFromError, Order} from "./errors-from-error";
 export {getKindFromError} from "./get-kind-from-error";
 export {getOriginalStackFromError} from "./get-original-stack-from-error";
+export {keys} from "./keys";
 export {KindError} from "./kind-error";
 export {safeStringify} from "./safe-stringify";
 export {truncateMiddle} from "./truncate-middle";
+export {values} from "./values";
 
 export type {Metadata, MetadataPrimitive, MetadataArray} from "./types";


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I had removed them in one of the PRs while migrating wonder-stuff to TypeScript and then I thought better of it and re-added them, but forgot to update index.ts so they were never exported by the package.  This audit fixes that.

Issue: None

## Test plan:
- yarn build
- check the build product to see that they're included and exported