### PR TITLE
Remove 'mixins' from .js.flow output

### DIFF
--- a/.changeset/quick-keys-learn.md
+++ b/.changeset/quick-keys-learn.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-stuff-core": patch
+"@khanacademy/wonder-stuff-sentry": patch
+---
+
+Update generate flow types to use 'extends' instead of 'mixins'

--- a/build-scripts/gen-flow-types.ts
+++ b/build-scripts/gen-flow-types.ts
@@ -1,4 +1,5 @@
 import {execFileSync} from "child_process";
+import * as fs from "fs";
 import * as path from "path";
 import * as fglob from "fast-glob";
 
@@ -14,6 +15,18 @@ for (const inFile of files) {
     try {
         execFileSync("yarn", args, {cwd: rootDir});
         console.log(`✅ wrote: ${outFile}`);
+
+        // `flowgen` sometimes outputs code that uses `mixins` instead of `extends`
+        // so we do some post-processing on the files to clean that up.
+        const contents = fs.readFileSync(path.join(rootDir, outFile), "utf-8");
+        if (contents.includes(" mixins ")) {
+            console.log("replacing 'mixins' with 'extends'");
+            fs.writeFileSync(
+                path.join(rootDir, outFile),
+                contents.replace(/ mixins /g, " extends "),
+                "utf-8",
+            );
+        }
     } catch (e) {
         console.log(`❌ error processing: ${inFile}: ${e}`);
     }


### PR DESCRIPTION
## Summary:
Some of the files flowgen was generated were using 'mixins' instead of 'extends'. This PR fixes this by post-processing the files.

Issue: None

## Test plan:
- yarn build:types
- yarn build:flowtypes
- search for 'mixins' in the dist/ folders, see that it no longer appears there