### PR TITLE
Fix issues with action() not being a getter on ITraceSession

### DIFF
--- a/.changeset/selfish-candles-call.md
+++ b/.changeset/selfish-candles-call.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-server-google": patch
+---
+
+Fix ITraceSession interface

--- a/packages/wonder-stuff-server-google/src/trace-impl.ts
+++ b/packages/wonder-stuff-server-google/src/trace-impl.ts
@@ -146,7 +146,6 @@ export const traceImpl = (
     };
 
     return {
-        // @ts-expect-error [FEI-5011] - TS2322 - Type 'string' is not assignable to type '() => string'.
         get action() {
             return action;
         },

--- a/packages/wonder-stuff-server-google/src/types.ts
+++ b/packages/wonder-stuff-server-google/src/types.ts
@@ -114,7 +114,7 @@ export interface ITraceSession {
     /**
      * The name of the action being traced as provided when it was started.
      */
-    action(): string;
+    get action(): string;
     /**
      * Add a label to the trace session.
      *


### PR DESCRIPTION
## Summary:
For some reason the 'get' modifier on the 'action()' getter in ITRaceSession was dropped when the files were converted to TypeScript.  I checked the other getters we have, which are on classes, but they weren't affected.  I suspect it's an issue with the codemod.  I'll investigate later and will patch is possible.

Issue: None

## Test plan:
- yarn typecheck