### PR TITLE
Fix wonder-stuff-i18n's dist/bin/ folder

### DIFF
--- a/.changeset/wise-trains-deny.md
+++ b/.changeset/wise-trains-deny.md
@@ -1,0 +1,6 @@
+---
+"ws-dev-build-settings": patch
+"@khanacademy/wonder-stuff-i18n": patch
+---
+
+Fix build script to output bin files using .js as their extension

--- a/build-settings/rollup.config.js
+++ b/build-settings/rollup.config.js
@@ -225,7 +225,7 @@ const getPackageInfo = (commandLineArgs, pkgName) => {
                 name: pkgName,
                 format: "cjs",
                 platform: "node",
-                file: `dist/bin/${binFile}`,
+                file: `dist/bin/${binFile.replace(/\.ts$/, ".js")}`,
                 inputFile: `./src/bin/${binFile}`,
                 plugins: [preserveShebangs(), rollupExecutable()],
             });


### PR DESCRIPTION
## Summary:
One of our cloud platform jobs is failing because dist/bin/gen-potfiles.ts was written instead of dist/bin/gen-profiles.js when wonder-stuff-i18n was built and published.  This PR fixes the issue by updating the build script to write bin files using hte .js extension instead of .ts.

Issue: None

## Test plan:
- ./packages/wonder-stuff-i18n/dist/bin/gen-potfile.js "../webapp/services/static/javascript/*.{js,jsx}" > JavaScript.pot
- cat JavaScript.pot
- see a bunch of strings ready for translations