### PR TITLE
[🔥AUDIT🔥] [fei4960.optionalauthentication] Make auth options optional again

### DIFF
--- a/packages/wonder-stuff-server/src/middleware/__tests__/request-authentication.test.ts
+++ b/packages/wonder-stuff-server/src/middleware/__tests__/request-authentication.test.ts
@@ -39,6 +39,32 @@ describe("#requestAuthentication", () => {
             expect(fakeNext).toHaveBeenCalledTimes(1);
         });
 
+        it("should log if no authentication options are provided", async () => {
+            // Arrange
+            const fakeAuthOptions = undefined;
+            const fakeNext = jest.fn();
+            const headers: Record<string, string> = {};
+            const fakeRequest: any = {
+                header: (name: string) => headers[name.toLowerCase()],
+                headers,
+            };
+            const fakeResponse: any = null;
+            const fakeLogger: any = {
+                debug: jest.fn(),
+            };
+            const middleware = await requestAuthentication(fakeAuthOptions);
+            jest.spyOn(GetLogger, "getLogger").mockReturnValue(fakeLogger);
+
+            // Act
+            middleware(fakeRequest, fakeResponse, fakeNext);
+
+            // Assert
+            expect(fakeLogger.debug).toHaveBeenCalledTimes(1);
+            expect(fakeLogger.debug.mock.calls[0][0]).toMatchInlineSnapshot(
+                `"No authentication header configured."`,
+            );
+        });
+
         it("should log if authentication header is omitted from request", async () => {
             // Arrange
             const fakeAuthOptions: any = {

--- a/packages/wonder-stuff-server/src/middleware/request-authentication.ts
+++ b/packages/wonder-stuff-server/src/middleware/request-authentication.ts
@@ -51,17 +51,19 @@ function makeProductionMiddleware(options: RequestAuthentication): Handler {
     };
 }
 
-function makeDevelopmentMiddleware(options: RequestAuthentication): Handler {
+function makeDevelopmentMiddleware(options?: RequestAuthentication): Handler {
     /**
      * The secrets middleware is a noop when not in production.
      */
     return function (req: Request, res: Response, next: NextFunction): void {
         const logger = getLogger(req);
-        // Let's log a message if the expected header is omitted. This is a
-        // valid thing to do in dev since we don't authenticate dev requests,
-        // but it is also useful to know during testing if the header is
-        // missing.
-        if (req.header(options.headerName) == null) {
+        if (options == null) {
+            logger.debug("No authentication header configured.");
+        } else if (req.header(options.headerName) == null) {
+            // Let's log a message if the expected header is omitted. This is a
+            // valid thing to do in dev since we don't authenticate dev
+            // requests, but it is also useful to know during testing if the
+            // header is missing.
             logger.warn("Authentication header was not included in request.", {
                 header: options.headerName,
             });
@@ -92,9 +94,9 @@ function makeDevelopmentMiddleware(options: RequestAuthentication): Handler {
  * matches it against the configured secret values.
  */
 export function requestAuthentication(
-    authenticationOptions: RequestAuthentication,
+    authenticationOptions?: RequestAuthentication,
 ): Handler {
-    if (getRuntimeMode() === "production") {
+    if (authenticationOptions != null && getRuntimeMode() === "production") {
         return makeProductionMiddleware(authenticationOptions);
     }
     return makeDevelopmentMiddleware(authenticationOptions);

--- a/packages/wonder-stuff-server/src/middleware/wrap-with-middleware.ts
+++ b/packages/wonder-stuff-server/src/middleware/wrap-with-middleware.ts
@@ -14,7 +14,7 @@ export const wrapWithMiddleware = async (
     app: Application,
     logger: Logger,
     mode: RuntimeValue,
-    requestAuthOptions: RequestAuthentication,
+    requestAuthOptions?: RequestAuthentication,
 ): Promise<Application> => {
     // Setup the middleware around the app.
     const appWithMiddleware = express()

--- a/packages/wonder-stuff-server/src/types.ts
+++ b/packages/wonder-stuff-server/src/types.ts
@@ -124,7 +124,7 @@ export type ServerOptions = {
     /**
      * Configuration information for authenticating requests.
      */
-    readonly requestAuthentication: RequestAuthentication;
+    readonly requestAuthentication?: RequestAuthentication;
     /**
      * Configuration for various Google Cloud agents that can aid debugging.
      */


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This makes the request authentication options optional as it used to be in the original implementation. This makes writing tests and example uses easier.

Issue: FEI-4960

## Test plan:
`yarn test`
`yarn typecheck`