### PR TITLE
[fei4960.3.rollup] Support dynamic import for all build types

### DIFF
--- a/.changeset/beige-dragons-kiss.md
+++ b/.changeset/beige-dragons-kiss.md
@@ -1,0 +1,5 @@
+---
+"ws-dev-build-settings": minor
+---
+
+Modified build process to support dynamic imports for all variations

--- a/.changeset/fast-frogs-shake.md
+++ b/.changeset/fast-frogs-shake.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-stuff-testing": minor
+"@khanacademy/wonder-stuff-sentry": minor
+"@khanacademy/wonder-stuff-core": minor
+---
+
+Modified browser builds to have their own folder so we can easily support dynamic import usage

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -118,7 +118,7 @@ jobs:
       uses: preactjs/compressed-size-action@v2
       with:
         # We only care about the browser ES module size, really:
-        pattern: "**/dist/es/index.browser.js"
+        pattern: "**/dist/browser/es/index.js"
         # Always ignore SourceMaps and node_modules:
         exclude: "{**/*.map,**/node_modules/**}"
         # Clean up before a build

--- a/packages/wonder-stuff-core/package.json
+++ b/packages/wonder-stuff-core/package.json
@@ -18,8 +18,8 @@
         "ws-dev-build-settings": "^1.0.0"
     },
     "browser": {
-        "dist/es/index.js": "./dist/es/index.browser.js",
-        "dist/index.js": "./dist/index.browser.js"
+        "dist/es/index.js": "./dist/browser/es/index.js",
+        "dist/index.js": "./dist/browser/index.js"
     },
     "author": "",
     "license": "MIT"

--- a/packages/wonder-stuff-sentry/package.json
+++ b/packages/wonder-stuff-sentry/package.json
@@ -21,8 +21,8 @@
         "ws-dev-build-settings": "^1.0.0"
     },
     "browser": {
-        "dist/es/index.js": "./dist/es/index.browser.js",
-        "dist/index.js": "./dist/index.browser.js"
+        "dist/es/index.js": "./dist/browser/es/index.js",
+        "dist/index.js": "./dist/browser/index.js"
     },
     "author": "",
     "license": "MIT"

--- a/packages/wonder-stuff-testing/package.json
+++ b/packages/wonder-stuff-testing/package.json
@@ -21,8 +21,8 @@
         "ws-dev-build-settings": "^1.0.0"
     },
     "browser": {
-        "dist/es/index.js": "./dist/es/index.browser.js",
-        "dist/index.js": "./dist/index.browser.js"
+        "dist/es/index.js": "./dist/browser/es/index.js",
+        "dist/index.js": "./dist/browser/index.js"
     },
     "author": "",
     "license": "MIT"

--- a/utils/pre-publish-utils.js
+++ b/utils/pre-publish-utils.js
@@ -57,8 +57,8 @@ const checkPrivate = (pkgJson) => {
 const checkBrowser = (pkgJson) => {
     if (pkgJson.browser) {
         const expectedValue = {
-            [pkgJson.main]: "./dist/index.browser.js",
-            [pkgJson.module]: "./dist/es/index.browser.js",
+            [pkgJson.main]: "./dist/browser/index.js",
+            [pkgJson.module]: "./dist/browser/es/index.js",
         };
 
         for (const key of Object.keys(pkgJson.browser)) {


### PR DESCRIPTION
## Summary:
This builds on the rollup config changes from the previous PR, making them more transparent and understandable, as well as making sure that it works for the browser builds, should they need it.

I bumped some package versions since this modifies the entrypoint paths for the browser builds.

Issue: FEI-4960

## Test plan:
`yarn build` and check the output.