### PR TITLE
Port checksync changes form eslint-plugin-khan

### DIFF
--- a/.changeset/khaki-files-punch.md
+++ b/.changeset/khaki-files-punch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-plugin": minor
+---
+
+Port checksync changes from old repo

--- a/packages/eslint-plugin-khan/README.md
+++ b/packages/eslint-plugin-khan/README.md
@@ -16,3 +16,4 @@ eslint plugin with our set of custom rules for various things
 - [khan/react-no-method-jsx-attribute](docs/react-no-method-jsx-attribute.md)
 - [khan/react-no-subscriptions-before-mount](docs/react-no-subscriptions-before-mount.md)
 - [khan/react-svg-path-precision](docs/react-svg-path-precision.md)
+- [khan/sync-tag](docs/sync-tag.md)

--- a/packages/eslint-plugin-khan/package.json
+++ b/packages/eslint-plugin-khan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khanacademy/eslint-plugin",
-  "version": "0.7.1",
+  "version": "1.3.1",
   "publishConfig": {
     "access": "public"
   },
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@babel/types": "^7.7.4",
-    "checksync": "^2.3.0"
+    "checksync": "^4.0.0"
   },
   "husky": {
     "hooks": {

--- a/packages/eslint-plugin-khan/test/sync-tag_test.js
+++ b/packages/eslint-plugin-khan/test/sync-tag_test.js
@@ -9,44 +9,103 @@ const parserOptions = {
 const ruleTester = new RuleTester(parserOptions);
 const rule = rules["sync-tag"];
 
-util.execFile = (file, ...args) => {
-    console.log("execFile mock --------");
-    const command = [file, ...args].join(" ");
+util.execSync = (command) => {
+    console.log("execSync mock --------");
     if (command.includes("filea")) {
         const json = JSON.stringify({
-            version: "2.2.3",
+            version: "4.0.0",
             launchString: "",
-            items: [],
+            files: {},
         });
         return json;
     }
     if (command.includes("filex")) {
         return JSON.stringify({
-            version: "2.2.3",
+            version: "4.0.0",
             launchString: "",
-            items: [
-                {
-                    type: "violation",
-                    sourceFile: "filex",
-                    sourceLine: 2,
-                    targetFile: "filey",
-                    targetLine: 23,
-                    message: `filex:15 Updating checksum for sync-tag 'foo-bar' referencing 'filey:23' from No checksum to 1424803960.`,
-                    fix: "// sync-start:foo-bar 1424803960 filey",
-                },
-            ],
+            files: {
+                filex: [
+                    {
+                        reason: "Looks like you changed the target content for sync-tag 'foo-bar' in 'filex:2'. Make sure you've made the parallel changes in the source file, if necessary (12352 != 249234014)",
+                        location: {
+                            line: 2,
+                        },
+                        code: "violation",
+                        fix: {
+                            type: "replace",
+                            line: 2,
+                            description:
+                                "Updated checksum for sync-tag 'foo-bar' referencing 'filex:2' from 12352 to 249234014.",
+                            declaration: "// sync-start:foo-bar filey",
+                            text: "// sync-start:foo-bar 1424803960 filey",
+                        },
+                    },
+                ],
+            },
+        });
+    }
+    if (command.includes("file_delete_tag")) {
+        return JSON.stringify({
+            version: "4.0.0",
+            launchString: "",
+            files: {
+                file_delete_tag: [
+                    {
+                        reason: "Duplicate target for sync-tag 'foo-bar'",
+                        location: {
+                            line: 2,
+                        },
+                        code: "violation",
+                        fix: {
+                            type: "delete",
+                            line: 3,
+                            description:
+                                "Removed duplicate target for sync-tag 'foo-bar'",
+                            declaration: "// sync-start:foo-bar filey",
+                        },
+                    },
+                ],
+            },
+        });
+    }
+    if (command.includes("file_unfixable")) {
+        return JSON.stringify({
+            version: "4.0.0",
+            launchString: "",
+            files: {
+                file_unfixable: [
+                    {
+                        reason: "Sync-start for 'foo-bar' points to 'filey', which does not exist or is a directory",
+                        location: {
+                            line: 2,
+                        },
+                        code: "file-does-not-exist",
+                    },
+                ],
+            },
         });
     }
     return "";
 };
 
-ruleTester.run("require-static-url", rule, {
+ruleTester.run("sync-tag", rule, {
     valid: [
         {
-            code: "// sync-start:foo-bar 1424803960 fileb\nconst FooBar = 'foobar';\n// sync-end:foobar",
+            code: "// sync-start:foo-bar 1424803960 fileb\nconst FooBar = 'foobar';\n// sync-end:foo-bar",
             filename: "filea",
             options: [
                 {
+                    ignoreFiles: ["lint_blacklist.txt"],
+                    rootDir: "/Users/nyancat/project",
+                },
+            ],
+        },
+        {
+            code: "// sync-start:foo-bar 1424803960 fileb\nconst FooBar = 'foobar';\n// sync-end:foo-bar",
+            filename: "filea",
+            options: [
+                {
+                    configFile: "./checksync.json",
                     ignoreFiles: ["lint_blacklist.txt"],
                     rootDir: "/Users/nyancat/project",
                 },
@@ -58,16 +117,57 @@ ruleTester.run("require-static-url", rule, {
             code: `
                 // sync-start:foo-bar filey
                 const FooBar = 'foobar';
-                // sync-end:foobar`,
+                // sync-end:foo-bar`,
             filename: "filex",
             errors: [
-                "filex:15 Updating checksum for sync-tag 'foo-bar' referencing 'filey:23' from No checksum to 1424803960. " +
-                    "If necessary, check the sync-tag target and make relevant changes before updating the checksum.",
+                "Looks like you changed the target content for sync-tag 'foo-bar' in 'filex:2'. Make sure you've made the parallel changes in the source file, if necessary (12352 != 249234014)",
             ],
             output: `
                 // sync-start:foo-bar 1424803960 filey
                 const FooBar = 'foobar';
-                // sync-end:foobar`,
+                // sync-end:foo-bar`,
+            options: [
+                {
+                    ignoreFiles: ["lint_blacklist.txt"],
+                    rootDir: "/Users/nyancat/project",
+                },
+            ],
+        },
+        {
+            code: `
+                // sync-start:foo-bar 1424803960 filey
+                // sync-start:foo-bar 1424803960 filey
+                const FooBar = 'foobar';
+                // sync-end:foo-bar`,
+            filename: "file_delete_tag",
+            errors: ["Duplicate target for sync-tag 'foo-bar'"],
+            // Prettier is removing whitespace within backticks, so I had to add
+            // the newlines manually.
+            output: `
+                // sync-start:foo-bar 1424803960 filey\n                \n                const FooBar = 'foobar';
+                // sync-end:foo-bar`,
+            options: [
+                {
+                    ignoreFiles: ["lint_blacklist.txt"],
+                    rootDir: "/Users/nyancat/project",
+                },
+            ],
+        },
+        {
+            code: `
+                // sync-start:foo-bar 1424803960 filey
+                const FooBar = 'foobar';
+                // sync-end:foo-bar`,
+            filename: "file_unfixable",
+            errors: [
+                "Sync-start for 'foo-bar' points to 'filey', which does not exist or is a directory",
+            ],
+            // Prettier is removing whitespace within backticks, so I had to add
+            // the newlines manually.
+            output: `
+                // sync-start:foo-bar 1424803960 filey
+                const FooBar = 'foobar';
+                // sync-end:foo-bar`,
             options: [
                 {
                     ignoreFiles: ["lint_blacklist.txt"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3242,10 +3242,10 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-checksync@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/checksync/-/checksync-2.3.0.tgz#d0801971aaa84a0adbc33734d1dab18f87ed54bd"
-  integrity sha512-QhR8MfvqAjo574gILPhGa1+j2NCyhhBC9biY1jigaPOnrtCO23QO+U+4cGfsw0IINXJd3yk6kcNtRKs5JYCdpg==
+checksync@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/checksync/-/checksync-4.0.0.tgz#fd74959cc91f665047ae94b541ab22007b0a9b53"
+  integrity sha512-G+wpCe4LfFLUSLCD+cSwF/stWXP9tm4M2Iy+8CBKiBX0izZ53nHTzbQ02aKfVxg6Q87e1xd/Q7AJbPXqiQxacw==
 
 chokidar@^3.4.3:
   version "3.5.3"


### PR DESCRIPTION
## Summary:
I forgot to 'git pull' in my local checkout of eslint-plugin-khan so the code I had locally was out of date.

I copied sync-tag.js and sync-tag_test.js wholesale from Khan/esling-plugin-khan@master and then ported the rest by hand using https://github.com/Khan/eslint-plugin-khan/compare/eedc8fe1794ef5fedc6d49578891854ac8193d75...master as a reference.

Issue: None

## Test plan:
- yarn --cwd packages/eslint-plugin-khan test