### PR TITLE
Fix sync-tag eslint rule

### DIFF
--- a/.changeset/eight-bats-beg.md
+++ b/.changeset/eight-bats-beg.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-plugin": patch
+---
+
+Ensure sync-tag rule has access to 'execSync'

--- a/packages/eslint-plugin-khan/lib/util.js
+++ b/packages/eslint-plugin-khan/lib/util.js
@@ -1,6 +1,7 @@
-const {execFile} = require("child_process");
+const {execFile, execSync} = require("child_process");
 
 // This is done so that we can override execSync in the tests
 module.exports = {
     execFile,
+    execSync,
 };

--- a/packages/eslint-plugin-khan/test/sync-tag_test.js
+++ b/packages/eslint-plugin-khan/test/sync-tag_test.js
@@ -1,3 +1,5 @@
+const assert = require("assert");
+
 const {rules} = require("../lib/index.js");
 const util = require("../lib/util.js");
 const RuleTester = require("eslint").RuleTester;
@@ -9,6 +11,7 @@ const parserOptions = {
 const ruleTester = new RuleTester(parserOptions);
 const rule = rules["sync-tag"];
 
+assert(util.execSync);
 util.execSync = (command) => {
     console.log("execSync mock --------");
     if (command.includes("filea")) {


### PR DESCRIPTION
## Summary:
The tests didn't catch this because they were mocking it.  The reason why we need to bother with these util wrappers around functions is that RuleTester doesn't provide a way to mock things so I ended up having to mock things in a hacky way.  I added an assert() call to the place where we do the mocking, but I think we need rethink how we write eslint tests.  We should probably create our own jest-based test harness, but that'll take some doing so I'm going to punt on it for now.

Issue: None

## Test plan:
- yarn --cwd packages/eslint-plugin-khan test