### PR TITLE
Remove logging from eslint-plugin-khan

### DIFF
--- a/.changeset/calm-schools-tease.md
+++ b/.changeset/calm-schools-tease.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-plugin": patch
+---
+
+Remove logging

--- a/packages/eslint-plugin-khan/.eslintrc.js
+++ b/packages/eslint-plugin-khan/.eslintrc.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-commonjs */
 module.exports = {
     rules: {
-        "no-console": "off",
         "import/extensions": "off",
         "import/no-commonjs": "off",
         "import/order": "off",

--- a/packages/eslint-plugin-khan/lib/rules/imports-requiring-flow.js
+++ b/packages/eslint-plugin-khan/lib/rules/imports-requiring-flow.js
@@ -9,9 +9,6 @@ const checkImport = (context, rootDir, importPath, node) => {
             ? testRulePath
             : `${testRulePath}${path.sep}`;
 
-        console.log("testImportPath = ", testImportPath);
-        console.log("testRulePath = ", testRulePath);
-
         // If the path is the same, then it's a match for the error.
         // If the path starts with the module listed, then it's also a match.
         if (

--- a/packages/eslint-plugin-khan/test/flow-array-type-style_test.js
+++ b/packages/eslint-plugin-khan/test/flow-array-type-style_test.js
@@ -1,10 +1,8 @@
 const {rules} = require("../lib/index.js");
 const RuleTester = require("eslint").RuleTester;
 
-const parserPath = require.resolve("@babel/eslint-parser");
-console.log("parserPath = ", parserPath);
 const parserOptions = {
-    parser: parserPath,
+    parser: require.resolve("@babel/eslint-parser"),
 };
 
 const ruleTester = new RuleTester(parserOptions);

--- a/packages/eslint-plugin-khan/test/imports-requiring-flow_test.js
+++ b/packages/eslint-plugin-khan/test/imports-requiring-flow_test.js
@@ -3,10 +3,8 @@ const path = require("path");
 const {rules} = require("../lib/index.js");
 const RuleTester = require("eslint").RuleTester;
 
-const parserPath = require.resolve("@babel/eslint-parser");
-console.log("parserPath = ", parserPath);
 const parserOptions = {
-    parser: parserPath,
+    parser: require.resolve("@babel/eslint-parser"),
 };
 
 const ruleTester = new RuleTester(parserOptions);

--- a/packages/eslint-plugin-khan/test/sync-tag_test.js
+++ b/packages/eslint-plugin-khan/test/sync-tag_test.js
@@ -13,6 +13,7 @@ const rule = rules["sync-tag"];
 
 assert(util.execSync);
 util.execSync = (command) => {
+    // eslint-disable-next-line no-console
     console.log("execSync mock --------");
     if (command.includes("filea")) {
         const json = JSON.stringify({


### PR DESCRIPTION
## Summary:
The console.logs make the CI logs really noisy and they don't need to be there.

Issue: None

## Test plan:
- yarn --cwd packages/eslint-plugin-khan test