### PR TITLE
Move TS enum eslint rules into config package

### DIFF
--- a/.changeset/long-houses-hear.md
+++ b/.changeset/long-houses-hear.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-config": minor
+---
+
+Add rules to ensure safe use of TS enums

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -161,11 +161,5 @@ module.exports = {
          * monorepo rules
          */
         "monorepo/no-internal-import": "error",
-
-        /**
-         * typescript rules
-         */
-        "@typescript-eslint/prefer-enum-initializers": "error",
-        "@typescript-eslint/prefer-literal-enum-member": "error",
     },
 };

--- a/packages/eslint-config-khan/index.js
+++ b/packages/eslint-config-khan/index.js
@@ -130,5 +130,7 @@ module.exports = {
             ERROR,
             {args: "none", varsIgnorePattern: "^_*$"},
         ],
+        "@typescript-eslint/prefer-enum-initializers": "error",
+        "@typescript-eslint/prefer-literal-enum-member": "error",
     },
 };

--- a/packages/eslint-config-khan/index.js
+++ b/packages/eslint-config-khan/index.js
@@ -89,7 +89,7 @@ module.exports = {
         /**
          * prettier rules
          */
-        "prettier/prettier": ["error", require("./.prettierrc")],
+        "prettier/prettier": [ERROR, require("./.prettierrc")],
 
         /**
          * react rules
@@ -125,12 +125,37 @@ module.exports = {
         /**
          * typescript rules
          */
-        "@typescript-eslint/no-explicit-any": "off",
+
+        // Disallow the `any` type.
+        //
+        // We've disabled this rule because most repos have too many uses of `any`
+        // for this to be useful.  Individual repos can enable this rule if they're
+        // in a position to do so.
+        //
+        // Docs: https://typescript-eslint.io/rules/no-explicit-any
+        "@typescript-eslint/no-explicit-any": OFF,
+
         "@typescript-eslint/no-unused-vars": [
             ERROR,
             {args: "none", varsIgnorePattern: "^_*$"},
         ],
-        "@typescript-eslint/prefer-enum-initializers": "error",
-        "@typescript-eslint/prefer-literal-enum-member": "error",
+
+        // Require each enum member value to be explicitly initialized.
+        //
+        // By default enums are assigned integer values starting with 0
+        // and ascending.  This can cause issue when removing or inserting
+        // new members in the enum since this can change their values.
+        // Requiring members to be explicitly initialized prevents this issue.
+        //
+        // Docs: https://typescript-eslint.io/rules/prefer-enum-initializers
+        "@typescript-eslint/prefer-enum-initializers": ERROR,
+
+        // Require all enum members to be literal values.
+        //
+        // Non-literal values can make it hard to tell what the value of a
+        // enum member is.
+        //
+        // Docs: https://typescript-eslint.io/rules/prefer-literal-enum-member
+        "@typescript-eslint/prefer-literal-enum-member": ERROR,
     },
 };


### PR DESCRIPTION
## Summary:
By moving these rules into the eslint-config-khan package, we can more easily adopt them in other repos.  In particular, if a repo is using dependabot then these new rules should be added automatically.

Issue: None

## Test plan:
- publish, see if dependenbot creates a PR in wonder-blocks with this change