### PR TITLE
FEI-5141.1: Add isTruthy and isNonNullable type predicates to wonder-stuff-core

### DIFF
--- a/.changeset/eighty-lobsters-flash.md
+++ b/.changeset/eighty-lobsters-flash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-core": minor
+---
+
+Add isTruthy and isNonNullable type predicates

--- a/packages/wonder-stuff-core/src/__tests__/type-predicates.test.ts
+++ b/packages/wonder-stuff-core/src/__tests__/type-predicates.test.ts
@@ -1,0 +1,27 @@
+import {isTruthy, isNonNullable} from "../type-predicates";
+
+describe("#isTruthy", () => {
+    it("can be used to filter an array so that only truthy values remain", () => {
+        // Arrange
+        const array = [0, 5, false, true, "", "hello", undefined, null];
+
+        // Act
+        const result = array.filter(isTruthy);
+
+        // Assert
+        expect(result).toEqual([5, true, "hello"]);
+    });
+});
+
+describe("#isNonNullable", () => {
+    it("can be used to filter an array so that only non-nullable values remain", () => {
+        // Arrange
+        const array = [0, 5, false, true, "", "hello", undefined, null];
+
+        // Act
+        const result = array.filter(isNonNullable);
+
+        // Assert
+        expect(result).toEqual([0, 5, false, true, "", "hello"]);
+    });
+});

--- a/packages/wonder-stuff-core/src/__tests__/type-predicates.typestest.ts
+++ b/packages/wonder-stuff-core/src/__tests__/type-predicates.typestest.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {isTruthy, isNonNullable} from "../type-predicates";
+
+const array = [0, 5, false, true, "", "hello", undefined, null];
+
+const truthyArray: Array<string | number | true> = array.filter(isTruthy);
+
+const nonNullableArray: Array<string | number | boolean> =
+    array.filter(isNonNullable);

--- a/packages/wonder-stuff-core/src/index.ts
+++ b/packages/wonder-stuff-core/src/index.ts
@@ -8,6 +8,7 @@ export {keys} from "./keys";
 export {KindError} from "./kind-error";
 export {safeStringify} from "./safe-stringify";
 export {truncateMiddle} from "./truncate-middle";
+export * from "./type-predicates";
 export {values} from "./values";
 export {secret} from "./secrets/secret";
 

--- a/packages/wonder-stuff-core/src/type-predicates.js.flow
+++ b/packages/wonder-stuff-core/src/type-predicates.js.flow
@@ -1,0 +1,10 @@
+type Falsy = false | 0 | "" | null | undefined;
+
+export function isTruthy<T>(x: T | Falsy): boolean %checks {
+    // NOTE(kevinb): Using `!!` in Flow does not provide the same type
+    // checking behavior that it does in TS, but `Boolean()` does.
+    return Boolean(x);
+}
+
+// NOTE(kevinb): There is no export for `isNonNullable` because I couldn't
+// create a predicate function in Flow that has the same behavior.

--- a/packages/wonder-stuff-core/src/type-predicates.ts
+++ b/packages/wonder-stuff-core/src/type-predicates.ts
@@ -1,0 +1,29 @@
+type Falsy = false | 0 | "" | null | undefined;
+
+/**
+ * This is a type predicate - if `x` is "truthy", then it's `T`.
+ *
+ * This can be used with Array's `.filter()` method to remove non-truthy values
+ * from an array, e.g.
+ *
+ *   const array = [0, 5, false, true, "", "hello", undefined, null];
+ *   const truthyArray = array.filter(isTruthy);
+ *
+ * `truthyArray` will be `[5, true, "hello"]` and will have the following type:
+ * `Array<string | number | true>`.
+ */
+export const isTruthy = <T>(x: T | Falsy): x is T => !!x;
+
+/**
+ * This is a type predicate - if `x` is neither `null` or `undefined`, then it's `T`.
+ *
+ * This can be used with Array's `.filter()` method to remove non-truthy
+ * values from an array, e.g.
+ *
+ *   const array = [0, 5, false, true, "", "hello", undefined, null];
+ *   const nonNullableArray = array.filter(isNonNullable);
+ *
+ * `nonNullableArray` will be `[0, 5, false, true, "", "hello"]` and will have the
+ * following type: `Array<string | number | boolean>`.
+ */
+export const isNonNullable = <T>(x: T | null | undefined): x is T => x != null;

--- a/packages/wonder-stuff-core/src/type-predicates.ts
+++ b/packages/wonder-stuff-core/src/type-predicates.ts
@@ -25,5 +25,8 @@ export const isTruthy = <T>(x: T | Falsy): x is T => !!x;
  *
  * `nonNullableArray` will be `[0, 5, false, true, "", "hello"]` and will have the
  * following type: `Array<string | number | boolean>`.
+ *
+ * NOTE: The term "nullable" in TypeScript refers to either `null` or `undefined`.
+ * This terminology is taken from https://www.typescriptlang.org/docs/handbook/utility-types.html#nonnullabletype.
  */
 export const isNonNullable = <T>(x: T | null | undefined): x is T => x != null;


### PR DESCRIPTION
## Summary:
.filter(Boolean) doesn't work in TS like it does in Flow. To address this issue, I'm adding a couple of type predicates to wonder-stuff-core.  I'll be updating webapp to use these predicates before the migration.  I'll also be creating a fixable eslint rule for this so that people trying to use '.filter(Boolean)' after the migration can easily move to the new pattern.

Issue: FEI-5141

TODO:
- [x] have a custom flow override for type-predicates.ts so that these predicates work under Flow as well

## Test plan:
- yarn tsc
- yarn test type-predicates
- yarn build:docs
- open docs/index.html
- see the beautiful docs

<img width="1904" alt="Screen Shot 2023-05-12 at 2 27 06 PM" src="https://github.com/Khan/wonder-stuff/assets/1044413/ca4ff20b-abbb-4956-831a-18e111cbae9c">
<img width="1904" alt="Screen Shot 2023-05-12 at 2 27 09 PM" src="https://github.com/Khan/wonder-stuff/assets/1044413/c6ec0f8c-6a0f-4403-b035-4345ca86be56">
