### PR TITLE
Tweak eslint rule options to not use "always"/"never"

### DIFF
--- a/.changeset/grumpy-hats-dress.md
+++ b/.changeset/grumpy-hats-dress.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-plugin": major
+---
+
+Remove always/never from eslint rule options

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 dist
 docs
+!packages/eslint-plugin-khan/docs
 !.vscode
 .DS_Store
 yarn-error.log

--- a/packages/eslint-plugin-khan/docs/ts-no-error-suppressions.md
+++ b/packages/eslint-plugin-khan/docs/ts-no-error-suppressions.md
@@ -1,0 +1,49 @@
+# Prevent the use of @ts-expect-error _et al_ on JSX attributes
+
+Using these TypeScript error suppressions on JSX attributes causes TS to opt out of
+type checking for all props/attributes on JSX elements, even those without an error
+suppression comment.
+
+## Rule Details
+
+The following are considered warnings:
+
+```js
+const MyComponent = () => {
+    return <Foo
+        // @ts-expect-error
+        onBar={() => {}}
+    />;
+}
+```
+
+```js
+const MyComponent = () => {
+    return <Foo
+        // @ts-ignore
+        onBar={() => {}}
+    />;
+}
+```
+
+The following are **not** considered warnings:
+
+```js
+const MyComponent = () => {
+    // @ts-expect-error
+    return <Foo
+        onBar={() => {}}
+    />;
+}
+```
+
+```js
+const MyComponent = () => {
+    return <Foo
+        onBar={(e) => {
+            // @ts-ignore
+            e.preventDefault();
+        }}
+    />;
+}
+```

--- a/packages/eslint-plugin-khan/src/rules/array-type-style.ts
+++ b/packages/eslint-plugin-khan/src/rules/array-type-style.ts
@@ -5,7 +5,7 @@ const createRule = ESLintUtils.RuleCreator(
         `https://github.com/Khan/wonder-stuff/blob/main/packages/eslint-plugin-khan/docs/${name}.md`,
 );
 
-type Options = ["always" | "never"];
+type Options = [];
 type MessageIds = "errorString";
 
 const message =
@@ -23,37 +23,28 @@ export default createRule<Options, MessageIds>({
         messages: {
             errorString: message,
         },
-        schema: [
-            {
-                enum: ["always", "never"],
-            },
-        ],
+        schema: [],
         type: "problem",
     },
 
     create(context) {
-        const configuration = context.options[0] || "never";
         const sourceCode = context.getSourceCode();
 
         return {
             TSArrayType(node) {
-                if (configuration === "always") {
-                    context.report({
-                        fix(fixer) {
-                            const type = node.elementType;
-                            const typeText = sourceCode.text.slice(
-                                ...type.range,
-                            );
-                            const replacementText = `Array<${typeText}>`;
+                context.report({
+                    fix(fixer) {
+                        const type = node.elementType;
+                        const typeText = sourceCode.text.slice(...type.range);
+                        const replacementText = `Array<${typeText}>`;
 
-                            return fixer.replaceText(node, replacementText);
-                        },
-                        node: node,
-                        messageId: "errorString",
-                    });
-                }
+                        return fixer.replaceText(node, replacementText);
+                    },
+                    node: node,
+                    messageId: "errorString",
+                });
             },
         };
     },
-    defaultOptions: ["always"],
+    defaultOptions: [],
 });

--- a/packages/eslint-plugin-khan/src/rules/jest-async-use-real-timers.ts
+++ b/packages/eslint-plugin-khan/src/rules/jest-async-use-real-timers.ts
@@ -91,7 +91,7 @@ const isAsync = (itCall: TSESTree.CallExpression) => {
     );
 };
 
-type Options = ["always" | "never"];
+type Options = [];
 type MessageIds = "errorString";
 
 const message = "Async tests require jest.useRealTimers().";
@@ -107,11 +107,7 @@ export default createRule<Options, MessageIds>({
         messages: {
             errorString: message,
         },
-        schema: [
-            {
-                enum: ["always", "never"],
-            },
-        ],
+        schema: [],
         type: "problem",
     },
 
@@ -152,5 +148,5 @@ export default createRule<Options, MessageIds>({
         };
     },
 
-    defaultOptions: ["always"],
+    defaultOptions: [],
 });

--- a/packages/eslint-plugin-khan/src/rules/jest-await-async-matchers.ts
+++ b/packages/eslint-plugin-khan/src/rules/jest-await-async-matchers.ts
@@ -34,13 +34,6 @@ const intersect = (
     return array1.filter((value) => array2.includes(value));
 };
 
-const getCustomMatchers = (options: Options) => {
-    if (options && options[0] && options[0].matchers) {
-        return options[0].matchers;
-    }
-    return [];
-};
-
 const DEFAULT_MATCHERS = [
     // built into jest
     "resolves",
@@ -81,8 +74,7 @@ export default createRule<Options, MessageIds>({
         type: "problem",
     },
 
-    create(context) {
-        const customMatchers = getCustomMatchers(context.options);
+    create(context, [{matchers: customMatchers}]) {
         const allowedMatchers = [...DEFAULT_MATCHERS, ...customMatchers];
 
         return {

--- a/packages/eslint-plugin-khan/src/rules/no-one-tuple.ts
+++ b/packages/eslint-plugin-khan/src/rules/no-one-tuple.ts
@@ -5,7 +5,7 @@ const createRule = ESLintUtils.RuleCreator(
         `https://github.com/Khan/wonder-stuff/blob/main/packages/eslint-plugin-khan/docs/${name}.md`,
 );
 
-type Options = ["always" | "never"];
+type Options = [];
 type MessageIds = "errorString";
 
 const message =
@@ -23,20 +23,16 @@ export default createRule<Options, MessageIds>({
         messages: {
             errorString: message,
         },
-        schema: [{enum: ["always", "never"]}],
+        schema: [],
         type: "problem",
     },
 
     create(context) {
-        const configuration = context.options[0] || "never";
         const sourceCode = context.getSourceCode();
 
         return {
             TSTupleType(node) {
-                if (
-                    configuration === "always" &&
-                    node.elementTypes.length === 1
-                ) {
+                if (node.elementTypes.length === 1) {
                     context.report({
                         fix(fixer) {
                             const type = node.elementTypes[0];
@@ -54,5 +50,5 @@ export default createRule<Options, MessageIds>({
             },
         };
     },
-    defaultOptions: ["always"],
+    defaultOptions: [],
 });

--- a/packages/eslint-plugin-khan/src/rules/react-no-method-jsx-attribute.ts
+++ b/packages/eslint-plugin-khan/src/rules/react-no-method-jsx-attribute.ts
@@ -11,7 +11,7 @@ const messages = {
 };
 
 type MessageIds = keyof typeof messages;
-type Options = ["always" | "never"];
+type Options = [];
 
 export default createRule<Options, MessageIds>({
     name: "react-no-method-jsx-attribute",
@@ -21,7 +21,7 @@ export default createRule<Options, MessageIds>({
             recommended: false,
         },
         messages,
-        schema: [{enum: ["always", "never"]}],
+        schema: [],
         type: "problem",
     },
 
@@ -86,5 +86,5 @@ export default createRule<Options, MessageIds>({
             },
         };
     },
-    defaultOptions: ["always"],
+    defaultOptions: [],
 });

--- a/packages/eslint-plugin-khan/src/rules/react-no-subscriptions-before-mount.ts
+++ b/packages/eslint-plugin-khan/src/rules/react-no-subscriptions-before-mount.ts
@@ -28,7 +28,7 @@ const beforeMountMethods = ["constructor", "componentWillMount"];
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
-type Options = ["always" | "never"];
+type Options = [];
 type MessageIds = keyof typeof messages;
 
 export default createRule<Options, MessageIds>({
@@ -41,11 +41,7 @@ export default createRule<Options, MessageIds>({
             recommended: false,
         },
         messages,
-        schema: [
-            {
-                enum: ["always", "never"],
-            },
-        ],
+        schema: [],
         type: "problem",
     },
     create(context) {
@@ -115,5 +111,5 @@ export default createRule<Options, MessageIds>({
             },
         };
     },
-    defaultOptions: ["always"],
+    defaultOptions: [],
 });

--- a/packages/eslint-plugin-khan/src/rules/react-svg-path-precision.ts
+++ b/packages/eslint-plugin-khan/src/rules/react-svg-path-precision.ts
@@ -85,5 +85,5 @@ export default createRule<Options, MessageIds>({
             },
         };
     },
-    defaultOptions: [{precision: 3}],
+    defaultOptions: [{precision: 2}],
 });

--- a/packages/eslint-plugin-khan/src/rules/react-svg-path-precision.ts
+++ b/packages/eslint-plugin-khan/src/rules/react-svg-path-precision.ts
@@ -42,16 +42,7 @@ export default createRule<Options, MessageIds>({
         type: "problem",
     },
 
-    create(context) {
-        let precision = 2;
-        for (const option of context.options) {
-            if (typeof option === "object") {
-                // eslint-disable-next-line no-prototype-builtins
-                if (option.hasOwnProperty("precision")) {
-                    precision = Math.max(option.precision, 0);
-                }
-            }
-        }
+    create(context, [{precision}]) {
         const pattern = `\\d*\\.\\d{${precision},}\\d+`;
         const regex = new RegExp(pattern, "g");
 

--- a/packages/eslint-plugin-khan/src/rules/ts-no-error-suppressions.ts
+++ b/packages/eslint-plugin-khan/src/rules/ts-no-error-suppressions.ts
@@ -5,7 +5,7 @@ const createRule = ESLintUtils.RuleCreator(
         `https://github.com/Khan/wonder-stuff/blob/main/packages/eslint-plugin-khan/docs/${name}.md`,
 );
 
-type Options = ["always" | "never"];
+type Options = [];
 type MessageIds = "errorString";
 
 const message = "{{type}} not allowed on JSXAttributes";
@@ -32,15 +32,11 @@ export default createRule<Options, MessageIds>({
         messages: {
             errorString: message,
         },
-        schema: [{enum: ["always", "never"]}],
+        schema: [],
         type: "problem",
     },
 
-    create(context, [mode]) {
-        if (mode === "never") {
-            return {};
-        }
-
+    create(context) {
         let tsComments: Array<TSESTree.Comment>;
 
         return {
@@ -87,5 +83,5 @@ export default createRule<Options, MessageIds>({
             },
         };
     },
-    defaultOptions: ["always"],
+    defaultOptions: [],
 });

--- a/packages/eslint-plugin-khan/test/rules/array-type-style.test.ts
+++ b/packages/eslint-plugin-khan/test/rules/array-type-style.test.ts
@@ -17,19 +17,16 @@ ruleTester.run(ruleName, rule, {
     valid: [
         {
             code: "type foo = { bar: Array<number> }",
-            options: ["always"],
         },
     ],
     invalid: [
         {
             code: "type foo = { bar: number[] }",
-            options: ["always"],
             errors: [{messageId: "errorString"}],
             output: "type foo = { bar: Array<number> }",
         },
         {
             code: "type foo = { bar: number[][] }",
-            options: ["always"],
             // Two errors are reported because there are two array types,
             // they just happen to be nested.
             errors: [{messageId: "errorString"}, {messageId: "errorString"}],

--- a/packages/eslint-plugin-khan/test/rules/no-one-tuple.test.ts
+++ b/packages/eslint-plugin-khan/test/rules/no-one-tuple.test.ts
@@ -17,23 +17,19 @@ ruleTester.run(ruleName, rule, {
     valid: [
         {
             code: "type foo = { bar: Array<number> }",
-            options: ["always"],
         },
         {
             code: "type foo = { bar: [number, number] }",
-            options: ["always"],
         },
     ],
     invalid: [
         {
             code: "type foo = { bar: [number] }",
-            options: ["always"],
             errors: [{messageId: "errorString"}],
             output: "type foo = { bar: Array<number> }",
         },
         {
             code: "type foo = { bar: [[number]] }",
-            options: ["always"],
             // Two errors are reported because there are two one-tuples,
             // they just happen to be nested.
             errors: [{messageId: "errorString"}, {messageId: "errorString"}],


### PR DESCRIPTION
## Summary:

We use "error", "warn", or "off" to control whether a rule runs or not.  The "always"/"never" option doesn't really make sense for the rules we currently have so I've removed those options from all of our eslint rules in this PR.

## Test Plan:
- yarn test eslint-plugin