### PR TITLE
FEI-5142: Add UnreachableCaseError for use in exhaustive switch-case statements

### DIFF
--- a/.changeset/sweet-apes-decide.md
+++ b/.changeset/sweet-apes-decide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-core": minor
+---
+
+Add UnreachableCaseError for use in exhaustive switch-case statements

--- a/packages/wonder-stuff-core/src/__tests__/unreachable-case-error.test.ts
+++ b/packages/wonder-stuff-core/src/__tests__/unreachable-case-error.test.ts
@@ -1,0 +1,72 @@
+import {Errors} from "../errors";
+import {UnreachableCaseError} from "../unreachable-case-error";
+
+describe("UnreachableCaseError", () => {
+    it("should have an appropriate error message", () => {
+        // Arrange
+        const message = "THE MESSAGE";
+
+        // Act
+        const action = () => {
+            // @ts-expect-error: this error should only be used in unreachable code
+            throw new UnreachableCaseError(message);
+        };
+
+        // Assert
+        expect(action).toThrowErrorMatchingInlineSnapshot(
+            `"Unhandled case for 'THE MESSAGE'"`,
+        );
+    });
+
+    it("should default .kind to Errors.InvalidInput", () => {
+        // Arrange
+        const message = "THE MESSAGE";
+
+        // Act
+        // @ts-expect-error: this error should only be used in unreachable code
+        const error = new UnreachableCaseError(message);
+
+        // Assert
+        expect(error.kind).toEqual(Errors.InvalidInput);
+    });
+
+    it("should set .kind to a different value when `kind` is passed in", () => {
+        // Arrange
+        const message = "THE MESSAGE";
+        const kind = Errors.NotFound;
+
+        // Act
+        // @ts-expect-error: this error should only be used in unreachable code
+        const error = new UnreachableCaseError(message, kind);
+
+        // Assert
+        expect(error.kind).toEqual(kind);
+    });
+
+    it("should default .cause to `undefined`", () => {
+        // Arrange
+        const message = "THE MESSAGE";
+
+        // Act
+        // @ts-expect-error: this error should only be used in unreachable code
+        const error = new UnreachableCaseError(message);
+
+        // Assert
+        expect(error.cause).toBeUndefined();
+    });
+
+    it("should set .cause when provided via options", () => {
+        // Arrange
+        const message = "THE MESSAGE";
+        const originalError = new Error("THE ORIGINAL MESSAGE");
+
+        // Act
+        // @ts-expect-error: this error should only be used in unreachable code
+        const error = new UnreachableCaseError(message, Errors.NotFound, {
+            cause: originalError,
+        });
+
+        // Assert
+        expect(error.cause).toEqual(originalError);
+    });
+});

--- a/packages/wonder-stuff-core/src/__tests__/unreachable-case-error.typestest.ts
+++ b/packages/wonder-stuff-core/src/__tests__/unreachable-case-error.typestest.ts
@@ -1,0 +1,34 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {UnreachableCaseError} from "../unreachable-case-error";
+
+type Action =
+    | {type: "delete"; id: string}
+    | {type: "insert"; id: string; value: any}
+    | {type: "update"; id: string; newValue: any};
+
+function exhaustive(action: Action) {
+    switch (action.type) {
+        case "delete":
+            break;
+        case "insert":
+            break;
+        case "update":
+            break;
+        default: {
+            throw new UnreachableCaseError(action);
+        }
+    }
+}
+
+function nonExhaustive(action: Action) {
+    switch (action.type) {
+        case "delete":
+            break;
+        case "insert":
+            break;
+        default: {
+            // @ts-expect-error: "update" isn't being handled
+            throw new UnreachableCaseError(action);
+        }
+    }
+}

--- a/packages/wonder-stuff-core/src/index.ts
+++ b/packages/wonder-stuff-core/src/index.ts
@@ -11,6 +11,7 @@ export {truncateMiddle} from "./truncate-middle";
 export * from "./type-predicates";
 export {values} from "./values";
 export {secret} from "./secrets/secret";
+export {UnreachableCaseError} from "./unreachable-case-error";
 
 export type {
     Metadata,

--- a/packages/wonder-stuff-core/src/unreachable-case-error.ts
+++ b/packages/wonder-stuff-core/src/unreachable-case-error.ts
@@ -1,0 +1,47 @@
+import {Errors} from "./errors";
+import {KindError, Options} from "./kind-error";
+
+/**
+ * An thin wrapper around KindError which can be used to ensure exhaustiveness
+ * of switch-case statements
+ *
+ * @param value The variable being refined by the switch-case statement.
+ *
+ * Example:
+ * ```
+ * import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
+ * type Action =
+ *   | {type: "insert"; id: string; value: any}
+ *   | {type: "delete"; id: string};
+ *
+ * function handleAction(action: Action) {
+ *   switch (action.type) {
+ *     case "insert": {
+ *       // do insert
+ *       break;
+ *     }
+ *     case "delete": {
+ *       // do delete
+ *     }
+ *     default: {
+ *       throw new UnreachableCaseError(action);
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * If a new action type is added to the `Action` type that isn't handled by
+ * the switch-case statement, the `default` case will become reachable and
+ * TypeScript will report an error.  This is becasue the first parameter of
+ * `UnreachableCaseError`'s constructor is typed as `never` and nothing can
+ * be assigned (or passed) to something typed as `never`.
+ */
+export class UnreachableCaseError extends KindError {
+    constructor(
+        value: never,
+        kind: string = Errors.InvalidInput,
+        options?: Options,
+    ) {
+        super(`Unhandled case for '${value}'`, kind, options);
+    }
+}

--- a/packages/wonder-stuff-core/src/unreachable-case-error.ts
+++ b/packages/wonder-stuff-core/src/unreachable-case-error.ts
@@ -22,6 +22,7 @@ import {KindError, Options} from "./kind-error";
  *     }
  *     case "delete": {
  *       // do delete
+ *       break;
  *     }
  *     default: {
  *       throw new UnreachableCaseError(action);


### PR DESCRIPTION
## Summary:
In webapp and mobile we have some exhaustive switch-case statements using `(value: empty)` in the `default` case so that Flow can ensure that we've handled all of the possible cases.  TS doesn't have the same kind of type assertions so we'll use `UnreachableCaseError` instead.  The constructor for this error class takes a parameter that is unassignable (it's typed as `never`).  This means if we don't handle all of the cases, TS will complain because the `default` case will be reachable now.  This same approach will work with Flow as will.  Once I've published wonder-stuff-core, I'll update webapp to make use of it.  The mobile repo has already been migrated to TS, but can still make use of this new error class.

Issue: FEI-5142

## Test plan:
- `yarn test unreachable-case-error`
- `yarn build:docs`
- `yarn tsc`
- `open docs/index.html`, see the docs for `UnreachableCaseError`

<img width="1904" alt="Screen Shot 2023-05-12 at 5 39 15 PM" src="https://github.com/Khan/wonder-stuff/assets/1044413/629e3a32-185a-46ca-848e-edc92aae1085">