### PR TITLE
Update eslint-config-khan to include @khanacademy/ts-no-error-suppressions

### DIFF
--- a/.changeset/good-months-change.md
+++ b/.changeset/good-months-change.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-config": minor
+---
+
+Add @khanacademy/ts-no-error-suppressions to config

--- a/packages/eslint-config-khan/index.js
+++ b/packages/eslint-config-khan/index.js
@@ -5,7 +5,13 @@ const ERROR = "error";
 
 module.exports = {
     parser: "@typescript-eslint/parser",
-    plugins: ["@typescript-eslint", "jsx-a11y", "prettier", "react"],
+    plugins: [
+        "@typescript-eslint",
+        "jsx-a11y",
+        "prettier",
+        "react",
+        "@khanacademy",
+    ],
     extends: [
         "eslint:recommended",
         "plugin:@typescript-eslint/eslint-recommended",
@@ -85,6 +91,14 @@ module.exports = {
         "jsx-a11y/aria-props": ERROR,
         "jsx-a11y/aria-role": [ERROR, {ignoreNonDOM: true}],
         "jsx-a11y/anchor-is-valid": ERROR,
+
+        /**
+         * khanacademy rules
+         */
+        // Prevents the use of @ts-expect-error, @ts-ignore, etc. comments on JSX attributes
+        // since this prevents TS from type checking any of the other attrs/props on the JSX
+        // element.
+        "@khanacademy/ts-no-error-suppressions": ERROR,
 
         /**
          * prettier rules

--- a/packages/eslint-config-khan/package.json
+++ b/packages/eslint-config-khan/package.json
@@ -9,16 +9,16 @@
     "repository": "git@github.com:Khan/eslint-config-khan.git",
     "author": "Kevin Barabash <kevinb@khanacademy.org>",
     "license": "MIT",
-    "dependencies": {},
     "peerDependencies": {
+        "@khanacademy/eslint-plugin": "^1.4.2",
         "@typescript-eslint/eslint-plugin": "^5.52.0",
         "@typescript-eslint/parser": "^5.52.0",
         "eslint": "^8.38.0",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-import-resolver-typescript": "^3.5.3",
         "eslint-plugin-import": "^2.23.4",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-prettier": "^3.4.0",
-        "eslint-plugin-react": "^7.24.0",
-        "eslint-import-resolver-typescript": "^3.5.3"
+        "eslint-plugin-react": "^7.24.0"
     }
 }


### PR DESCRIPTION
## Summary:
The ts-no-error-suppressions error should be used in all of our repos with React code that have been converted to TypeScript. This PR updates our eslint config to include this rule.

Issue: None

## Test plan:
- yarn build
- reload the eslint plugin in VSCode
- see that VSCode is no longer complaining about it not being able to find the rule
- node utils/pre-publish-check-ci.js  

NOTE: Khan/actions@check-for-changet will fail until https://github.com/Khan/actions/pull/44 is landed.