### PR TITLE
[fixwscibuild] Make sure peer dependencies are added for wonder-stuff-ci

### DIFF
--- a/.changeset/ten-ladybugs-develop.md
+++ b/.changeset/ten-ladybugs-develop.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-ci": major
+---
+
+Add peer dependencies so that the build is complete

--- a/packages/wonder-stuff-ci/package.json
+++ b/packages/wonder-stuff-ci/package.json
@@ -22,5 +22,14 @@
     "license": "MIT",
     "dependencies": {
         "@khanacademy/wonder-stuff-server": "^4.0.7"
+    },
+    "peerDependencies": {
+        "@google-cloud/kms": "^3.4.0",
+        "@google-cloud/logging-winston": "^4.1.1",
+        "@google-cloud/profiler": "^4.1.7",
+        "@google-cloud/trace-agent": "^5.1.6",
+        "express": "^4.17.2",
+        "express-winston": "^4.2.0",
+        "winston": "^3.4.0"
     }
 }


### PR DESCRIPTION
## Summary:
This ensures that we don't try to inline the logging-winston code, which incorrectly excludes some of the code

Issue: XXX-XXXX

## Test plan:
`yarn build` and check that `./common` is not in the index.js for wonder-stuff-ci.

We'll also test this in @jlauzy's work where this issue was identified.