### PR TITLE
Cleaned up the code and fix the logger for new required type by GCP API

### DIFF
--- a/.changeset/tricky-pillows-sin.md
+++ b/.changeset/tricky-pillows-sin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-ci": minor
+---
+
+Update the library to fix GCP api changes

--- a/packages/wonder-stuff-ci/package.json
+++ b/packages/wonder-stuff-ci/package.json
@@ -6,7 +6,7 @@
         "node": ">=16"
     },
     "name": "@khanacademy/wonder-stuff-ci",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Functions for automation and scripts.",
     "module": "dist/es/index.js",
     "main": "dist/index.js",

--- a/packages/wonder-stuff-ci/package.json
+++ b/packages/wonder-stuff-ci/package.json
@@ -6,7 +6,7 @@
         "node": ">=16"
     },
     "name": "@khanacademy/wonder-stuff-ci",
-    "version": "1.1.0",
+    "version": "1.0.0",
     "description": "Functions for automation and scripts.",
     "module": "dist/es/index.js",
     "main": "dist/index.js",

--- a/packages/wonder-stuff-ci/src/__tests__/get-gcp-log-transport.test.ts
+++ b/packages/wonder-stuff-ci/src/__tests__/get-gcp-log-transport.test.ts
@@ -9,6 +9,7 @@ describe("#getGCPLogTransport", () => {
             level: "info",
             redirectToStdout: true,
             labels: {test: "test"},
+            resource: {type: "global"},
         });
 
         // Assert

--- a/packages/wonder-stuff-ci/src/__tests__/get-mobile-release-logger.test.ts
+++ b/packages/wonder-stuff-ci/src/__tests__/get-mobile-release-logger.test.ts
@@ -3,7 +3,7 @@ import {getMobileReleaseLogger} from "../get-mobile-release-logger";
 describe("#getMobileReleaseLogger", () => {
     it("return the mobile release logger", () => {
         // Act
-        const result = getMobileReleaseLogger();
+        const result = getMobileReleaseLogger({});
 
         // Assert
         expect(result).toBeTruthy();

--- a/packages/wonder-stuff-ci/src/get-gcp-log-transport.ts
+++ b/packages/wonder-stuff-ci/src/get-gcp-log-transport.ts
@@ -15,9 +15,7 @@ export const getGCPLogTransport = (
         projectId: options.projectId,
         logName: options.logName,
         level: options.level,
-        resource: {
-            labels: options.labels,
-        },
+        resource: options.resource,
         defaultCallback: (err) => {
             if (err) {
                 // eslint-disable-next-line no-console

--- a/packages/wonder-stuff-ci/src/get-mobile-release-logger.ts
+++ b/packages/wonder-stuff-ci/src/get-mobile-release-logger.ts
@@ -7,50 +7,36 @@ import {
 import * as winston from "winston";
 
 import {getGCPLogTransport} from "./get-gcp-log-transport";
-import {GCPLogLevels} from "./types";
+import {MobileReleaseLoggerOptions} from "./types";
 
 let logger: winston.Logger | null = null;
 
 /**
- * Logger for auditing mobile release events.
- * @param {boolean} redirectToStdout If true, logs will be written to stdout.
- * @param {{[key: string]: string}} labels K/V metadata that will be add to the logs
- * @param {GCPLogLevels} logLevel The log level to send to GCP.
- * @param {string} logName The name of the log to send logs to in GCP.
- * @param {string} projectId The GCP project ID to send logs to.
+ * Logger for auditing mobile release events with default values.
  */
-export const getMobileReleaseLogger = (
-    {
-        redirectToStdout,
-        labels,
-        logLevel,
-        logName,
-        projectId,
-    }: {
-        redirectToStdout: boolean;
-        labels: {[key: string]: string};
-        logLevel: GCPLogLevels;
-        logName: string;
-        projectId: string;
-    } = {
-        redirectToStdout: false,
-        labels: {},
-        logLevel: "info",
-        logName: "release-raccoon",
-        projectId: "mobile-365917",
+export const getMobileReleaseLogger = ({
+    redirectToStdout = false,
+    labels = {},
+    logLevel = "info",
+    logName = "release-raccoon",
+    projectId = "mobile-365917",
+    defaultMetadata = {},
+    resource = {
+        type: "global",
     },
-): winston.Logger => {
+}: MobileReleaseLoggerOptions): winston.Logger => {
     if (!logger) {
         logger = createLogger({
             mode: Runtime.Production,
             level: logLevel,
-            defaultMetadata: {},
+            defaultMetadata: defaultMetadata,
             transport: getGCPLogTransport({
                 projectId: projectId,
                 logName: logName,
                 level: logLevel,
                 redirectToStdout: redirectToStdout,
                 labels: labels,
+                resource: resource,
             }),
         });
         setRootLogger(logger);

--- a/packages/wonder-stuff-ci/src/types.ts
+++ b/packages/wonder-stuff-ci/src/types.ts
@@ -27,9 +27,50 @@ export type GCPTransportOptions = {
      */
     level: string;
     /**
-     * K/V metadata that will be add to the logs
+     * K/V labels that will be add to the logs
      */
     labels: {[key: string]: string};
+    /**
+     * K/V for setting the resource values for GCP
+     */
+    resource: {[key: string]: string};
 };
 
+/**
+ * The gcp log levels that are supported.
+ */
 export type GCPLogLevels = "debug" | "info" | "warn" | "error";
+
+/**
+ * The options for the mobile release logger.
+ */
+export type MobileReleaseLoggerOptions = {
+    /**
+     * If true, logs will be written to stdout.
+     */
+    redirectToStdout?: boolean;
+    /**
+     * K/V labels that will be add to the logs
+     */
+    labels?: {[key: string]: string};
+    /**
+     * The minimum log level to send to GCP.
+     */
+    logLevel?: GCPLogLevels;
+    /**
+     * The name of the log to send logs to in GCP.
+     */
+    logName?: string;
+    /**
+     * The GCP project ID to send logs to.
+     */
+    projectId?: string;
+    /**
+     * K/V metadata that will be add to each the log
+     */
+    defaultMetadata?: {[key: string]: string};
+    /**
+     * K/V for setting the resource values for GCP, where resource.type is required by GCP API.
+     */
+    resource?: {[key: string]: string};
+};


### PR DESCRIPTION
## Summary:
- The logger no longer works because GCP's API made a breaking change where the resource type is required.
- Cleaned up the code to have more flexibility for these changes by exposing more configuration to the client.

![image](https://github.com/Khan/wonder-stuff/assets/34088613/284361a2-66cf-4530-a0cb-cc98ab5df3a1)

I'm pretty sure they are going to make a change to their SDK so that this is no longer nullable but required
![image](https://github.com/Khan/wonder-stuff/assets/34088613/40a43925-4d81-4416-ad6b-7186ce449163)


Issue: XXX-XXXX

## Test plan:
Works Again!
![image](https://github.com/Khan/wonder-stuff/assets/34088613/e1223935-c04d-46a6-b366-4f30328368fe)
