### PR TITLE
Fix exports of isTruthy and isNonNullable

### DIFF
--- a/.changeset/six-glasses-flow.md
+++ b/.changeset/six-glasses-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-core": patch
+---
+
+Make sure isTruthy and isNonNullable get exported

--- a/packages/wonder-stuff-core/src/index.ts
+++ b/packages/wonder-stuff-core/src/index.ts
@@ -8,7 +8,7 @@ export {keys} from "./keys";
 export {KindError} from "./kind-error";
 export {safeStringify} from "./safe-stringify";
 export {truncateMiddle} from "./truncate-middle";
-export * from "./type-predicates";
+export {isTruthy, isNonNullable} from "./type-predicates";
 export {values} from "./values";
 export {secret} from "./secrets/secret";
 export {UnreachableCaseError} from "./unreachable-case-error";

--- a/packages/wonder-stuff-core/src/type-predicates.js.flow
+++ b/packages/wonder-stuff-core/src/type-predicates.js.flow
@@ -6,5 +6,9 @@ export function isTruthy<T>(x: T | Falsy): boolean %checks {
     return Boolean(x);
 }
 
-// NOTE(kevinb): There is no export for `isNonNullable` because I couldn't
-// create a predicate function in Flow that has the same behavior.
+// NOTE(kevinb): This doesn't work properly with .filter() and only is only
+// here so to avoid issues with the re-export in index.js since Flow doesn't
+// recognize `export * from "..."` in .js.flow files for some reason.
+export function isNonNullable<T>(x: ?T): boolean %checks {
+    return x != null;
+}


### PR DESCRIPTION
## Summary:
For some reason 'export * from ...' doesn't work.

Issue: None

## Test plan:
- yarn build
- check the dist/index.js for wonder-stuff-core to see that 'isTruthy' and 'isNonNullable' both appear in the output