### PR TITLE
Re-add old eslint rules

### DIFF
--- a/.changeset/kind-balloons-move.md
+++ b/.changeset/kind-balloons-move.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-plugin": minor
+---
+
+Re-add old eslint rules

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ coverage
 **/*.template
 **/package.json
 **/*.md
+docs/assets/main.js

--- a/config/jest/test.config.js
+++ b/config/jest/test.config.js
@@ -13,7 +13,7 @@ module.exports = {
     restoreMocks: true,
     resetMocks: true,
     testEnvironment: "jest-environment-node",
-    testMatch: ["<rootDir>/**/*.test.ts", "<rootDir>/**/*.test.js"],
+    testMatch: ["<rootDir>/**/*.test.ts"],
     setupFilesAfterEnv: [
         "jest-extended/all",
         "<rootDir>/config/jest/test-setup.js",

--- a/config/jest/test.config.js
+++ b/config/jest/test.config.js
@@ -13,7 +13,7 @@ module.exports = {
     restoreMocks: true,
     resetMocks: true,
     testEnvironment: "jest-environment-node",
-    testMatch: ["<rootDir>/**/*.test.ts"],
+    testMatch: ["<rootDir>/**/*.test.ts", "<rootDir>/**/*.test.js"],
     setupFilesAfterEnv: [
         "jest-extended/all",
         "<rootDir>/config/jest/test-setup.js",

--- a/packages/eslint-plugin-khan/.mocharc.js
+++ b/packages/eslint-plugin-khan/.mocharc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    extension: ["js", "ts"],
+    spec: "test/**/*.test.js",
+    require: "@swc-node/register",
+};

--- a/packages/eslint-plugin-khan/package.json
+++ b/packages/eslint-plugin-khan/package.json
@@ -17,12 +17,16 @@
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-flow": "^7.22.5",
     "@babel/preset-react": "^7.22.5",
+    "@swc-node/register": "^1.6.6",
+    "@swc/core": "^1.3.67",
     "eslint": "^8.43.0",
+    "mocha": "^10.2.0",
     "prettier": "^2.8.8",
     "pretty-quick": "^3.1.3"
   },
   "scripts": {
-    "prettier": "prettier --write '{lib,test}/**/*.js'"
+    "prettier": "prettier --write '{lib,test}/**/*.{js,ts}'",
+    "test": "mocha"
   },
   "dependencies": {
     "@babel/types": "^7.22.5",

--- a/packages/eslint-plugin-khan/src/react-utils.js
+++ b/packages/eslint-plugin-khan/src/react-utils.js
@@ -1,0 +1,28 @@
+import * as t from "@babel/types";
+
+export const isReactClassComponent = (node) => {
+    if (t.isClassDeclaration(node)) {
+        const {superClass} = node;
+        if (t.isMemberExpression(superClass)) {
+            const {object, property} = superClass;
+            if (
+                t.isIdentifier(object, {name: "React"}) &&
+                t.isIdentifier(property, {name: "Component"})
+            ) {
+                return true;
+            }
+        }
+    }
+    return false;
+};
+
+export const isReactFunctionalComponent = (node) => {
+    if (t.isArrowFunctionExpression(node)) {
+        if (
+            node.params.length === 1 &&
+            t.isIdentifier(node.params[0], {name: "props"})
+        ) {
+            return true;
+        }
+    }
+};

--- a/packages/eslint-plugin-khan/src/rules/flow-array-type-style.js
+++ b/packages/eslint-plugin-khan/src/rules/flow-array-type-style.js
@@ -1,0 +1,44 @@
+const message =
+    "Shorthand syntax for array types can appear ambiguous.  " +
+    "Please use the long-form: Array<>";
+
+export default {
+    meta: {
+        docs: {
+            description: "Prefer Array<T> to T[]",
+            category: "flow",
+            recommended: false,
+        },
+        fixable: "code",
+        schema: [
+            {
+                enum: ["always", "never"],
+            },
+        ],
+    },
+
+    create(context) {
+        const configuration = context.options[0] || "never";
+        const sourceCode = context.getSource();
+
+        return {
+            ArrayTypeAnnotation(node) {
+                if (configuration === "always") {
+                    context.report({
+                        fix(fixer) {
+                            const type = node.elementType;
+                            const typeText = sourceCode.slice(...type.range);
+                            const replacementText = `Array<${typeText}>`;
+
+                            return fixer.replaceText(node, replacementText);
+                        },
+                        node: node,
+                        message: message,
+                    });
+                }
+            },
+        };
+    },
+
+    __message: message,
+};

--- a/packages/eslint-plugin-khan/src/rules/flow-exact-props.js
+++ b/packages/eslint-plugin-khan/src/rules/flow-exact-props.js
@@ -1,9 +1,9 @@
 import * as t from "@babel/types";
 
-const {
+import {
     isReactClassComponent,
     isReactFunctionalComponent,
-} = require("../react-utils.js");
+} from "../react-utils";
 
 const maybeReport = (node, typeAnnotation, typeAliases, context) => {
     if (t.isGenericTypeAnnotation(typeAnnotation)) {

--- a/packages/eslint-plugin-khan/src/rules/flow-exact-props.js
+++ b/packages/eslint-plugin-khan/src/rules/flow-exact-props.js
@@ -1,0 +1,76 @@
+import * as t from "@babel/types";
+
+const {
+    isReactClassComponent,
+    isReactFunctionalComponent,
+} = require("../react-utils.js");
+
+const maybeReport = (node, typeAnnotation, typeAliases, context) => {
+    if (t.isGenericTypeAnnotation(typeAnnotation)) {
+        const {name} = typeAnnotation.id;
+        const alias = typeAliases.get(name);
+        if (alias && !alias.right.exact) {
+            const sourceCode = context.getSource();
+            context.report({
+                fix(fixer) {
+                    const right = alias.right;
+                    const rightText = sourceCode.slice(
+                        right.range[0] + 1,
+                        right.range[1] - 1,
+                    );
+                    const replacementText = `{|${rightText}|}`;
+
+                    return fixer.replaceText(alias.right, replacementText);
+                },
+                node: alias,
+                message: `"${name}" type should be exact`,
+            });
+        }
+    }
+};
+
+export default {
+    meta: {
+        docs: {
+            description: "Prefer exact object type for react props",
+            category: "flow",
+            recommended: false,
+        },
+        fixable: "code",
+    },
+
+    create(context) {
+        const configuration = context.options[0] || "never";
+        const typeAliases = new Map();
+
+        return {
+            TypeAlias(node) {
+                const ancestors = context.getAncestors();
+                if (
+                    t.isProgram(node.parent) &&
+                    t.isObjectTypeAnnotation(node.right)
+                ) {
+                    typeAliases.set(node.id.name, node);
+                }
+            },
+            ClassDeclaration(node) {
+                if (isReactClassComponent(node)) {
+                    const {superTypeParameters} = node;
+                    if (t.isTypeParameterInstantiation(superTypeParameters)) {
+                        const props = superTypeParameters.params[0];
+                        maybeReport(node, props, typeAliases, context);
+                    }
+                }
+            },
+            ArrowFunctionExpression(node) {
+                if (isReactFunctionalComponent(node)) {
+                    const {typeAnnotation} = node.params[0];
+                    if (t.isTypeAnnotation(typeAnnotation)) {
+                        const props = typeAnnotation.typeAnnotation;
+                        maybeReport(node, props, typeAliases, context);
+                    }
+                }
+            },
+        };
+    },
+};

--- a/packages/eslint-plugin-khan/src/rules/flow-exact-state.js
+++ b/packages/eslint-plugin-khan/src/rules/flow-exact-state.js
@@ -1,6 +1,6 @@
 import * as t from "@babel/types";
 
-const {isReactClassComponent} = require("../react-utils.js");
+import {isReactClassComponent} from "../react-utils";
 
 const maybeReport = (node, typeAnnotation, typeAliases, context) => {
     if (t.isGenericTypeAnnotation(typeAnnotation)) {

--- a/packages/eslint-plugin-khan/src/rules/flow-exact-state.js
+++ b/packages/eslint-plugin-khan/src/rules/flow-exact-state.js
@@ -1,0 +1,66 @@
+import * as t from "@babel/types";
+
+const {isReactClassComponent} = require("../react-utils.js");
+
+const maybeReport = (node, typeAnnotation, typeAliases, context) => {
+    if (t.isGenericTypeAnnotation(typeAnnotation)) {
+        const {name} = typeAnnotation.id;
+        const alias = typeAliases.get(name);
+        if (alias && !alias.right.exact) {
+            const sourceCode = context.getSource();
+            context.report({
+                fix(fixer) {
+                    const right = alias.right;
+                    const rightText = sourceCode.slice(
+                        right.range[0] + 1,
+                        right.range[1] - 1,
+                    );
+                    const replacementText = `{|${rightText}|}`;
+
+                    return fixer.replaceText(alias.right, replacementText);
+                },
+                node: alias,
+                message: `"${name}" type should be exact`,
+            });
+        }
+    }
+};
+
+export default {
+    meta: {
+        docs: {
+            description: "Prefer exact object type for react state",
+            category: "flow",
+            recommended: false,
+        },
+        fixable: "code",
+    },
+
+    create(context) {
+        const configuration = context.options[0] || "never";
+        const typeAliases = new Map();
+
+        return {
+            TypeAlias(node) {
+                const ancestors = context.getAncestors();
+                if (
+                    t.isProgram(node.parent) &&
+                    t.isObjectTypeAnnotation(node.right)
+                ) {
+                    typeAliases.set(node.id.name, node);
+                }
+            },
+            ClassDeclaration(node) {
+                if (isReactClassComponent(node)) {
+                    const {superTypeParameters} = node;
+                    if (t.isTypeParameterInstantiation(superTypeParameters)) {
+                        const [props, state] = superTypeParameters.params;
+                        if (state) {
+                            maybeReport(node, state, typeAliases, context);
+                        }
+                    }
+                }
+            },
+        };
+    },
+};

--- a/packages/eslint-plugin-khan/src/rules/flow-no-one-tuple.js
+++ b/packages/eslint-plugin-khan/src/rules/flow-no-one-tuple.js
@@ -1,0 +1,44 @@
+const message =
+    "One-tuples can be confused with shorthand syntax for array types.  " +
+    "Using Array<> avoids this confusion.";
+
+export default {
+    meta: {
+        docs: {
+            description: "Disallow one-tuple",
+            category: "flow",
+            recommended: false,
+        },
+        fixable: "code",
+        schema: [
+            {
+                enum: ["always", "never"],
+            },
+        ],
+    },
+
+    create(context) {
+        const configuration = context.options[0] || "never";
+        const sourceCode = context.getSource();
+
+        return {
+            TupleTypeAnnotation(node) {
+                if (configuration === "always" && node.types.length === 1) {
+                    context.report({
+                        fix(fixer) {
+                            const type = node.types[0];
+                            const typeText = sourceCode.slice(...type.range);
+                            const replacementText = `Array<${typeText}>`;
+
+                            return fixer.replaceText(node, replacementText);
+                        },
+                        node: node,
+                        message: message,
+                    });
+                }
+            },
+        };
+    },
+
+    __message: message,
+};

--- a/packages/eslint-plugin-khan/src/rules/imports-requiring-flow.js
+++ b/packages/eslint-plugin-khan/src/rules/imports-requiring-flow.js
@@ -1,0 +1,130 @@
+const path = require("path");
+
+const checkImport = (context, rootDir, importPath, node) => {
+    const maybeReport = (importPath, testRulePath, testImportPath) => {
+        // TODO(somewhatabstract): This is not cross-platform. We need to do
+        // more work to make this rule work on Windows properly, regardless of
+        // the configuration format.
+        const subRulePath = testRulePath.endsWith(path.sep)
+            ? testRulePath
+            : `${testRulePath}${path.sep}`;
+
+        // If the path is the same, then it's a match for the error.
+        // If the path starts with the module listed, then it's also a match.
+        if (
+            testImportPath === testRulePath ||
+            testImportPath.startsWith(subRulePath)
+        ) {
+            context.report({
+                node,
+                message: `Importing "${importPath}" requires using flow.`,
+            });
+            return true;
+        }
+        return false;
+    };
+
+    const modules = context.options[0].modules || [];
+
+    for (const mod of modules) {
+        if (importPath.startsWith(".")) {
+            const filename = context.getFilename();
+            const absImportPath = path.join(path.dirname(filename), importPath);
+            const absModPath = path.join(rootDir, mod);
+            if (maybeReport(importPath, absModPath, absImportPath)) {
+                break;
+            }
+        } else {
+            if (maybeReport(importPath, mod, importPath)) {
+                break;
+            }
+        }
+    }
+
+    const regexes = context.options[0].regexes || [];
+
+    for (const src of regexes) {
+        const regex = new RegExp(src);
+        if (regex.test(importPath)) {
+            context.report({
+                node,
+                message: `Importing "${importPath}" requires using flow.`,
+            });
+            break;
+        }
+    }
+};
+
+const isRequire = ({callee}) =>
+    callee.type === "Identifier" && callee.name === "require";
+const isDynamicImport = ({callee}) => callee.type === "Import";
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Require flow when using certain imports",
+            category: "flow",
+            recommended: false,
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    modules: {
+                        type: "array",
+                        items: {
+                            type: "string",
+                        },
+                    },
+                    regexes: {
+                        type: "array",
+                        items: {
+                            type: "string",
+                        },
+                    },
+                    rootDir: {
+                        type: "string",
+                    },
+                },
+            },
+        ],
+    },
+
+    create(context) {
+        const rootDir = context.options[0].rootDir;
+        if (!rootDir) {
+            throw new Error("rootDir must be set");
+        }
+
+        let usingFlow = false;
+        return {
+            Program(node) {
+                usingFlow = node.comments.some(
+                    (comment) => comment.value.trim() === "@flow",
+                );
+            },
+            ImportDeclaration(node) {
+                if (!usingFlow) {
+                    const importPath = node.source.value;
+                    checkImport(context, rootDir, importPath, node);
+                }
+            },
+            ImportExpression(node) {
+                if (!usingFlow) {
+                    const importPath = node.source.value;
+                    checkImport(context, rootDir, importPath, node);
+                }
+            },
+            // legacy support for dynamic imports
+            CallExpression(node) {
+                const {arguments: args} = node;
+                if (!usingFlow && (isRequire(node) || isDynamicImport(node))) {
+                    if (args[0] && args[0].type === "Literal") {
+                        const importPath = args[0].value;
+                        checkImport(context, rootDir, importPath, node);
+                    }
+                }
+            },
+        };
+    },
+};

--- a/packages/eslint-plugin-khan/src/rules/index.ts
+++ b/packages/eslint-plugin-khan/src/rules/index.ts
@@ -8,6 +8,12 @@ import reactSvgPathPrecision from "./react-svg-path-precision";
 import syncTag from "./sync-tag";
 import tsNoErrorSupressions from "./ts-no-error-suppressions";
 
+import jestEnzymeMatchers from "./jest-enzyme-matchers";
+import flowArrayTypeStyle from "./flow-array-type-style";
+import flowExactProps from "./flow-exact-props";
+import flowExactState from "./flow-exact-state";
+import flowNoOneTuple from "./flow-no-one-tuple";
+
 export default {
     "array-type-style": arrayTypeStyle,
     "jest-async-use-real-timers": jestAsyncUseRealTimers,
@@ -18,4 +24,10 @@ export default {
     "react-no-subscriptions-before-mount": reactNoSubscriptionsBeforeMount,
     "react-svg-path-precision": reactSvgPathPrecision,
     "sync-tag": syncTag,
+
+    "flow-array-type-style": flowArrayTypeStyle,
+    "flow-exact-props": flowExactProps,
+    "flow-exact-state": flowExactState,
+    "flow-no-one-tuple": flowNoOneTuple,
+    "jest-enzyme-matchers": jestEnzymeMatchers,
 };

--- a/packages/eslint-plugin-khan/src/rules/jest-enzyme-matchers.js
+++ b/packages/eslint-plugin-khan/src/rules/jest-enzyme-matchers.js
@@ -1,0 +1,232 @@
+import * as t from "@babel/types";
+
+export default {
+    meta: {
+        docs: {
+            description:
+                "Requires the use more of enzyme matchers where appropriate.",
+            category: "jest",
+            recommended: false,
+        },
+        fixable: true,
+    },
+
+    create(context) {
+        const stack = [];
+
+        return {
+            CallExpression(node) {
+                if (
+                    t.isIdentifier(node.callee, {name: "expect"}) &&
+                    t.isCallExpression(node.arguments[0]) &&
+                    t.isMemberExpression(node.arguments[0].callee) &&
+                    t.isMemberExpression(node.parent) &&
+                    t.isIdentifier(node.parent.property) &&
+                    t.isCallExpression(node.parent.parent)
+                ) {
+                    const {property} = node.arguments[0].callee;
+                    const matcher = node.parent.property.name;
+
+                    if (matcher === "toEqual") {
+                        if (t.isIdentifier(property, {name: "prop"})) {
+                            const sourceCode = context.getSource();
+                            const propName = node.arguments[0].arguments[0];
+                            const expected = sourceCode.slice(
+                                ...node.parent.parent.arguments[0].range,
+                            );
+                            context.report({
+                                node,
+                                message: `Use .toHaveProp(${propName.raw}, ${expected}) instead.`,
+                                fix(fixer) {
+                                    const actual = sourceCode.slice(
+                                        ...node.arguments[0].callee.object
+                                            .range,
+                                    );
+                                    const text = `expect(${actual}).toHaveProp(${propName.raw}, ${expected})`;
+                                    return fixer.replaceText(
+                                        node.parent.parent,
+                                        text,
+                                    );
+                                },
+                            });
+                        } else if (t.isIdentifier(property, {name: "state"})) {
+                            const sourceCode = context.getSource();
+                            const stateKey = node.arguments[0].arguments[0];
+                            const expected = sourceCode.slice(
+                                ...node.parent.parent.arguments[0].range,
+                            );
+                            context.report({
+                                node,
+                                message: `Use .toHaveState(${stateKey.raw}, ${expected}) instead.`,
+                                fix(fixer) {
+                                    const actual = sourceCode.slice(
+                                        ...node.arguments[0].callee.object
+                                            .range,
+                                    );
+                                    const text = `expect(${actual}).toHaveState(${stateKey.raw}, ${expected})`;
+                                    return fixer.replaceText(
+                                        node.parent.parent,
+                                        text,
+                                    );
+                                },
+                            });
+                        } else if (t.isIdentifier(property, {name: "text"})) {
+                            const sourceCode = context.getSource();
+                            const expected = sourceCode.slice(
+                                ...node.parent.parent.arguments[0].range,
+                            );
+                            context.report({
+                                node,
+                                message: `Use .toHaveText(${expected}) instead.`,
+                                fix(fixer) {
+                                    const actual = sourceCode.slice(
+                                        ...node.arguments[0].callee.object
+                                            .range,
+                                    );
+                                    const text = `expect(${actual}).toHaveText(${expected})`;
+                                    return fixer.replaceText(
+                                        node.parent.parent,
+                                        text,
+                                    );
+                                },
+                            });
+                        } else if (t.isIdentifier(property, {name: "html"})) {
+                            const sourceCode = context.getSource();
+                            const expected = sourceCode.slice(
+                                ...node.parent.parent.arguments[0].range,
+                            );
+                            context.report({
+                                node,
+                                message: `Use .toHaveHTML(${expected}) instead.`,
+                                fix(fixer) {
+                                    const actual = sourceCode.slice(
+                                        ...node.arguments[0].callee.object
+                                            .range,
+                                    );
+                                    const text = `expect(${actual}).toHaveHTML(${expected})`;
+                                    return fixer.replaceText(
+                                        node.parent.parent,
+                                        text,
+                                    );
+                                },
+                            });
+                        }
+                    } else if (
+                        matcher === "toBeTrue" ||
+                        matcher === "toBeTruthy"
+                    ) {
+                        if (t.isIdentifier(property, {name: "exists"})) {
+                            if (node.arguments[0].arguments.length === 0) {
+                                const sourceCode = context.getSource();
+                                context.report({
+                                    node,
+                                    message: `Use .toExist() instead.`,
+                                    fix(fixer) {
+                                        const actual = sourceCode.slice(
+                                            ...node.arguments[0].callee.object
+                                                .range,
+                                        );
+                                        const text = `expect(${actual}).toExist()`;
+                                        return fixer.replaceText(
+                                            node.parent.parent,
+                                            text,
+                                        );
+                                    },
+                                });
+                            } else {
+                                const sourceCode = context.getSource();
+                                const selector = sourceCode.slice(
+                                    ...node.arguments[0].arguments[0].range,
+                                );
+                                context.report({
+                                    node,
+                                    message: `Use .toContainMatchingElement(${selector}) instead.`,
+                                    fix(fixer) {
+                                        const actual = sourceCode.slice(
+                                            ...node.arguments[0].callee.object
+                                                .range,
+                                        );
+                                        const text = `expect(${actual}).toContainMatchingElement(${selector})`;
+                                        return fixer.replaceText(
+                                            node.parent.parent,
+                                            text,
+                                        );
+                                    },
+                                });
+                            }
+                        }
+                    } else if (
+                        matcher === "toBeFalse" ||
+                        matcher === "toBeFalsy"
+                    ) {
+                        if (t.isIdentifier(property, {name: "exists"})) {
+                            if (node.arguments[0].arguments.length === 0) {
+                                const sourceCode = context.getSource();
+                                context.report({
+                                    node,
+                                    message: `Use .not.toExist() instead.`,
+                                    fix(fixer) {
+                                        const actual = sourceCode.slice(
+                                            ...node.arguments[0].callee.object
+                                                .range,
+                                        );
+                                        const text = `expect(${actual}).not.toExist()`;
+                                        return fixer.replaceText(
+                                            node.parent.parent,
+                                            text,
+                                        );
+                                    },
+                                });
+                            } else {
+                                const sourceCode = context.getSource();
+                                const selector = sourceCode.slice(
+                                    ...node.arguments[0].arguments[0].range,
+                                );
+                                context.report({
+                                    node,
+                                    message: `Use .not.toContainMatchingElement(${selector}) instead.`,
+                                    fix(fixer) {
+                                        const actual = sourceCode.slice(
+                                            ...node.arguments[0].callee.object
+                                                .range,
+                                        );
+                                        const text = `expect(${actual}).not.toContainMatchingElement(${selector})`;
+                                        return fixer.replaceText(
+                                            node.parent.parent,
+                                            text,
+                                        );
+                                    },
+                                });
+                            }
+                        }
+                    } else if (matcher === "toHaveLength") {
+                        if (t.isIdentifier(property, {name: "find"})) {
+                            const sourceCode = context.getSource();
+                            const selector = sourceCode.slice(
+                                ...node.arguments[0].arguments[0].range,
+                            );
+                            const count = sourceCode.slice(
+                                ...node.parent.parent.arguments[0].range,
+                            );
+                            context.report({
+                                node,
+                                message: `Use .toContainMatchingElements(${count}, ${selector}) instead.`,
+                                fix(fixer) {
+                                    const actual = sourceCode.slice(
+                                        ...node.arguments[0].callee.object
+                                            .range,
+                                    );
+                                    const text = `expect(${actual}).toContainMatchingElements(${count}, ${selector})`;
+                                    return fixer.replaceText(
+                                        node.parent.parent,
+                                        text,
+                                    );
+                                },
+                            });
+                        }
+                    }
+                }
+            },
+        };
+    },
+};

--- a/packages/eslint-plugin-khan/test/rules/flow-array-type-style.test.js
+++ b/packages/eslint-plugin-khan/test/rules/flow-array-type-style.test.js
@@ -1,0 +1,40 @@
+import {RuleTester} from "eslint";
+
+import {rules} from "../../src/index";
+
+const parserOptions = {
+    parser: require.resolve("@babel/eslint-parser"),
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const rule = rules["flow-array-type-style"];
+
+const message = rule.__message;
+const errors = [message];
+
+ruleTester.run("flow-array-type-style", rule, {
+    valid: [
+        {
+            code: "type foo = { bar: Array<number> }",
+            options: ["always"],
+        },
+    ],
+    invalid: [
+        {
+            code: "type foo = { bar: number[] }",
+            options: ["always"],
+            errors: errors,
+            output: "type foo = { bar: Array<number> }",
+        },
+        {
+            code: "type foo = { bar: number[][] }",
+            options: ["always"],
+            // Two errors are reported because there are two array types,
+            // they just happen to be nested.
+            errors: [message, message],
+            // This is a partial fix.  Multiple runs of eslint --fix are needed
+            // to fix nested (in the AST) array types completely.
+            output: "type foo = { bar: Array<number>[] }",
+        },
+    ],
+});

--- a/packages/eslint-plugin-khan/test/rules/flow-exact-props.test.js
+++ b/packages/eslint-plugin-khan/test/rules/flow-exact-props.test.js
@@ -1,0 +1,78 @@
+import {RuleTester} from "eslint";
+
+import {rules} from "../../src/index";
+
+const parserOptions = {
+    parser: require.resolve("@babel/eslint-parser"),
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const rule = rules["flow-exact-props"];
+
+const message = rule.__message;
+
+ruleTester.run("flow-exact-props", rule, {
+    valid: [
+        {
+            code: `
+        type Props = {| x: number |};
+        class Foo extends React.Component<Props> {}`,
+        },
+        {
+            code: `
+        type BarProps = { x: number };
+        type FooProps = {| x: number |};
+        class Foo extends React.Component<FooProps> {}`,
+        },
+        {
+            code: `
+        type Props = {| x: number |};
+        const Foo = (props: Props) => {}`,
+        },
+    ],
+    invalid: [
+        {
+            code: `
+        type Props = { x: number };
+        class Foo extends React.Component<Props> {}`,
+            errors: ['"Props" type should be exact'],
+            output: `
+        type Props = {| x: number |};
+        class Foo extends React.Component<Props> {}`,
+        },
+        {
+            code: `
+        type FooProps = { x: number };
+        class Foo extends React.Component<FooProps> {}`,
+            errors: ['"FooProps" type should be exact'],
+            output: `
+        type FooProps = {| x: number |};
+        class Foo extends React.Component<FooProps> {}`,
+        },
+        {
+            code: `
+        type FooProps = { x: number };
+        class Foo extends React.Component<FooProps> {}
+        type BarProps = { x: number };
+        class Bar extends React.Component<BarProps> {}`,
+            errors: [
+                '"FooProps" type should be exact',
+                '"BarProps" type should be exact',
+            ],
+            output: `
+        type FooProps = {| x: number |};
+        class Foo extends React.Component<FooProps> {}
+        type BarProps = {| x: number |};
+        class Bar extends React.Component<BarProps> {}`,
+        },
+        {
+            code: `
+type Props = { x: number };
+const Foo = (props: Props) => {}`,
+            errors: ['"Props" type should be exact'],
+            output: `
+type Props = {| x: number |};
+const Foo = (props: Props) => {}`,
+        },
+    ],
+});

--- a/packages/eslint-plugin-khan/test/rules/flow-exact-state.test.js
+++ b/packages/eslint-plugin-khan/test/rules/flow-exact-state.test.js
@@ -1,0 +1,75 @@
+import {RuleTester} from "eslint";
+
+import {rules} from "../../src/index";
+
+const parserOptions = {
+    parser: require.resolve("@babel/eslint-parser"),
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const rule = rules["flow-exact-state"];
+
+const message = rule.__message;
+const errors = [message];
+
+ruleTester.run("flow-exact-state", rule, {
+    valid: [
+        {
+            code: `
+        type Props = { x: number };
+        type State = {| x: number |};
+        class Foo extends React.Component<Props, State> {}`,
+        },
+        {
+            code: `
+        type FooProps = { x: number };
+        type BarState = { x: number };
+        type FooState = {| x: number |};
+        class Foo extends React.Component<FooProps, FooState> {}`,
+        },
+    ],
+    invalid: [
+        {
+            code: `
+        type Props = {| x: number |};
+        type State = { x: number };
+        class Foo extends React.Component<Props, State> {}`,
+            errors: ['"State" type should be exact'],
+            output: `
+        type Props = {| x: number |};
+        type State = {| x: number |};
+        class Foo extends React.Component<Props, State> {}`,
+        },
+        {
+            code: `
+        type FooProps = {| x: number |};
+        type FooState = { x: number };
+        class Foo extends React.Component<FooProps, FooState> {}`,
+            errors: ['"FooState" type should be exact'],
+            output: `
+        type FooProps = {| x: number |};
+        type FooState = {| x: number |};
+        class Foo extends React.Component<FooProps, FooState> {}`,
+        },
+        {
+            code: `
+        type FooProps = { x: number };
+        type FooState = { x: number };
+        class Foo extends React.Component<FooProps, FooState> {}
+        type BarProps = { x: number };
+        type BarState = { x: number };
+        class Bar extends React.Component<BarProps, BarState> {}`,
+            errors: [
+                '"FooState" type should be exact',
+                '"BarState" type should be exact',
+            ],
+            output: `
+        type FooProps = { x: number };
+        type FooState = {| x: number |};
+        class Foo extends React.Component<FooProps, FooState> {}
+        type BarProps = { x: number };
+        type BarState = {| x: number |};
+        class Bar extends React.Component<BarProps, BarState> {}`,
+        },
+    ],
+});

--- a/packages/eslint-plugin-khan/test/rules/flow-no-one-tuple.test.js
+++ b/packages/eslint-plugin-khan/test/rules/flow-no-one-tuple.test.js
@@ -1,0 +1,44 @@
+import {RuleTester} from "eslint";
+
+import {rules} from "../../src/index";
+
+const parserOptions = {
+    parser: require.resolve("@babel/eslint-parser"),
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const rule = rules["flow-no-one-tuple"];
+
+const message = rule.__message;
+const errors = [message];
+
+ruleTester.run("flow-no-one-tuple", rule, {
+    valid: [
+        {
+            code: "type foo = { bar: Array<number> }",
+            options: ["always"],
+        },
+        {
+            code: "type foo = { bar: [number, number] }",
+            options: ["always"],
+        },
+    ],
+    invalid: [
+        {
+            code: "type foo = { bar: [number] }",
+            options: ["always"],
+            errors: errors,
+            output: "type foo = { bar: Array<number> }",
+        },
+        {
+            code: "type foo = { bar: [[number]] }",
+            options: ["always"],
+            // Two errors are reported because there are two one-tuples,
+            // they just happen to be nested.
+            errors: [message, message],
+            // This is a partial fix.  Multiple runs of eslint --fix are needed
+            // to fix nested 1-tuples completely.
+            output: "type foo = { bar: Array<[number]> }",
+        },
+    ],
+});

--- a/packages/eslint-plugin-khan/test/rules/jest-enzyme-matchers.test.js
+++ b/packages/eslint-plugin-khan/test/rules/jest-enzyme-matchers.test.js
@@ -1,0 +1,149 @@
+import {RuleTester} from "eslint";
+
+import {rules} from "../../src/index";
+
+const parserOptions = {
+    parser: require.resolve("@babel/eslint-parser"),
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const rule = rules["jest-enzyme-matchers"];
+
+ruleTester.run("jest-real-timers", rule, {
+    valid: [
+        {
+            code: 'expect(wrapper).toHaveProp("foo", "bar");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper).toHaveState("foo", "bar");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper).toContainMatchingElements(1, ".foo");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper.find(".foo")).toHaveText("bar");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper.find(".foo")).toHaveHTML("<p>bar</p>");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper.find(".foo")).toExist();',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper).toContainMatchingElement(".foo");',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper.find(".foo")).not.toExist();',
+            options: [],
+        },
+        {
+            code: 'expect(wrapper).not.toContainMatchingElement(".foo");',
+            options: [],
+        },
+    ],
+    invalid: [
+        {
+            code: `expect(wrapper.prop("foo")).toEqual("bar");`,
+            options: [],
+            errors: ['Use .toHaveProp("foo", "bar") instead.'],
+            output: 'expect(wrapper).toHaveProp("foo", "bar");',
+        },
+        {
+            code: `expect(wrapper.first().prop("foo")).toEqual("bar");`,
+            options: [],
+            errors: ['Use .toHaveProp("foo", "bar") instead.'],
+            output: 'expect(wrapper.first()).toHaveProp("foo", "bar");',
+        },
+        {
+            code: `expect(wrapper.state("foo")).toEqual("bar");`,
+            options: [],
+            errors: ['Use .toHaveState("foo", "bar") instead.'],
+            output: 'expect(wrapper).toHaveState("foo", "bar");',
+        },
+        {
+            code: `expect(wrapper.first().state("foo")).toEqual("bar");`,
+            options: [],
+            errors: ['Use .toHaveState("foo", "bar") instead.'],
+            output: 'expect(wrapper.first()).toHaveState("foo", "bar");',
+        },
+        {
+            code: `expect(wrapper.find(".foo")).toHaveLength(1);`,
+            options: [],
+            errors: ['Use .toContainMatchingElements(1, ".foo") instead.'],
+            output: 'expect(wrapper).toContainMatchingElements(1, ".foo");',
+        },
+        {
+            code: `expect(wrapper.find(".foo")).toHaveLength(2);`,
+            options: [],
+            errors: ['Use .toContainMatchingElements(2, ".foo") instead.'],
+            output: 'expect(wrapper).toContainMatchingElements(2, ".foo");',
+        },
+        {
+            code: `expect(wrapper.find(".foo").text()).toEqual("bar");`,
+            options: [],
+            errors: ['Use .toHaveText("bar") instead.'],
+            output: 'expect(wrapper.find(".foo")).toHaveText("bar");',
+        },
+        {
+            code: `expect(wrapper.find(".foo").html()).toEqual("<p>bar</p>");`,
+            options: [],
+            errors: ['Use .toHaveHTML("<p>bar</p>") instead.'],
+            output: 'expect(wrapper.find(".foo")).toHaveHTML("<p>bar</p>");',
+        },
+        {
+            code: `expect(wrapper.find(".foo").exists()).toBeTrue();`,
+            options: [],
+            errors: ["Use .toExist() instead."],
+            output: 'expect(wrapper.find(".foo")).toExist();',
+        },
+        {
+            code: `expect(wrapper.find(".foo").exists()).toBeTruthy();`,
+            options: [],
+            errors: ["Use .toExist() instead."],
+            output: 'expect(wrapper.find(".foo")).toExist();',
+        },
+        {
+            code: `expect(wrapper.exists(".foo")).toBeTrue();`,
+            options: [],
+            errors: ['Use .toContainMatchingElement(".foo") instead.'],
+            output: 'expect(wrapper).toContainMatchingElement(".foo");',
+        },
+        {
+            code: `expect(wrapper.exists(".foo")).toBeTruthy();`,
+            options: [],
+            errors: ['Use .toContainMatchingElement(".foo") instead.'],
+            output: 'expect(wrapper).toContainMatchingElement(".foo");',
+        },
+        {
+            code: `expect(wrapper.find(".foo").exists()).toBeFalse();`,
+            options: [],
+            errors: ["Use .not.toExist() instead."],
+            output: 'expect(wrapper.find(".foo")).not.toExist();',
+        },
+        {
+            code: `expect(wrapper.find(".foo").exists()).toBeFalsy();`,
+            options: [],
+            errors: ["Use .not.toExist() instead."],
+            output: 'expect(wrapper.find(".foo")).not.toExist();',
+        },
+        {
+            code: `expect(wrapper.exists(".foo")).toBeFalse();`,
+            options: [],
+            errors: ['Use .not.toContainMatchingElement(".foo") instead.'],
+            output: 'expect(wrapper).not.toContainMatchingElement(".foo");',
+        },
+        {
+            code: `expect(wrapper.exists(".foo")).toBeFalsy();`,
+            options: [],
+            errors: ['Use .not.toContainMatchingElement(".foo") instead.'],
+            output: 'expect(wrapper).not.toContainMatchingElement(".foo");',
+        },
+    ],
+});

--- a/tsconfig-common.json
+++ b/tsconfig-common.json
@@ -22,6 +22,7 @@
         "strictPropertyInitialization": true,
         "strictBindCallApply": true,
         "noImplicitAny": true,
+        "allowJs": true,
 
         /* Completeness */
         "skipDefaultLibCheck": true, // it's safe to assume that built-in .d.ts files are correct

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,50 +2134,100 @@
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.66.tgz#b34a396479ca8fc82876d6dfb28c78a51010e6ce"
   integrity sha512-UijJsvuLy73vxeVYEy7urIHksXS+3BdvJ9s9AY+bRMSQW483NO7RLp8g4FdTyJbRaN0BH15SQnY0dcjQBkVuHw==
 
+"@swc/core-darwin-arm64@1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.67.tgz#8076dcd75862b92a7987a8da5a24986ab559d793"
+  integrity sha512-zCT2mCkOBVNf5uJDcQ3A9KDoO1OEaGdfjsRTZTo7sejDd9AXLfJg+xgyCBBrK2jNS/uWcT21IvSv3LqKp4K8pA==
+
 "@swc/core-darwin-x64@1.3.66":
   version "1.3.66"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.66.tgz#b778e434d29652eae6da6ee7ed335605f7cfd866"
   integrity sha512-xGsHKvViQnwTNLF30Y/5OqWdnN6RsiyUI8awZXfz1sHcXCEaLe+v+WLQ+/E8sgw0YUkYVHzzfV/sAN2CezJK5Q==
+
+"@swc/core-darwin-x64@1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.67.tgz#49da279b06232a388e9c9179db1cbff81d3dee18"
+  integrity sha512-hXTVsfTatPEec5gFVyjGj3NccKZsYj/OXyHn6XA+l3Q76lZzGm2ISHdku//XNwXu8OmJ0HhS7LPsC4XXwxXQhg==
 
 "@swc/core-linux-arm-gnueabihf@1.3.66":
   version "1.3.66"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.66.tgz#a7ab556dc9fc770069fea292ff5551161df83a70"
   integrity sha512-gNbLcSIV2pq90BkMSpzvK4xPXOl8GEF3YR4NaqF0CYSzQsVXXTTqMuX/r26xNYudBKzH0345S1MpoRk2qricnA==
 
+"@swc/core-linux-arm-gnueabihf@1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.67.tgz#668645ac62ea7beb4319d177f43cdefb0326cd90"
+  integrity sha512-l8AKL0RkDL5FRTeWMmjoz9zvAc37amxC+0rheaNwE+gZya7ObyNjnIYz5FwN+3y+z6JFU7LS2x/5f6iwruv6pg==
+
 "@swc/core-linux-arm64-gnu@1.3.66":
   version "1.3.66"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.66.tgz#00591f5fd0d9f1d1ed565329936451eb6d0d5433"
   integrity sha512-cJSQ0oplyWbJqy4rzVcnBYLAi6z1QT3QCcR7iAey0aAmCvfRBZJfXlyjggMjn4iosuadkauwCZR1xYNhBDRn7w==
+
+"@swc/core-linux-arm64-gnu@1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.67.tgz#709bccc5ced37b64ab5ae479bf73fc2ab5ef0b48"
+  integrity sha512-S8zOB1AXEpb7kmtgMaFNeLAj01VOky4B0RNZ+uJWigdrDiFT67FeZzNHUNmNSOU0QM79G+Lie/xD/beqEw0vDg==
 
 "@swc/core-linux-arm64-musl@1.3.66":
   version "1.3.66"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.66.tgz#dd8e5e7b1154b5a42a32d57914e0de2cef6686ff"
   integrity sha512-GDQZpcB9aGxG9PTA2shdIkoMZlGK5omJ8NR49uoBTtLBVYiGeXAwV0U1Uaw8kXEZj9i7wZDkvjzjSaNH3evRsg==
 
+"@swc/core-linux-arm64-musl@1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.67.tgz#9187378e17200b1ffb3d06b78c4a33f85dd12efb"
+  integrity sha512-Fex8J8ASrt13pmOr2xWh41tEeKWwXYGk3sV8L/aGHiYtIJEUi2f+RtMx3jp7LIdOD8pQptor7i5WBlfR9jhp8A==
+
 "@swc/core-linux-x64-gnu@1.3.66":
   version "1.3.66"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.66.tgz#35de4b88e3f256e7923503a8031569c733859b68"
   integrity sha512-lg8E4O/Pd9KfK0lajdinVMuGME8dSv7V9arhEpmlfGE2eXSDCWqDn5Htk5QVBstt9lt1lsRhWHJ/YYc2eQY30Q==
+
+"@swc/core-linux-x64-gnu@1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.67.tgz#bcdaf46c430bc85a59ae9b38ab9bd540aa1fbd2d"
+  integrity sha512-9bz9/bMphrv5vDg0os/d8ve0QgFpDzJgZgHUaHiGwcmfnlgdOSAaYJLIvWdcGTjZuQeV4L0m+iru357D9TXEzA==
 
 "@swc/core-linux-x64-musl@1.3.66":
   version "1.3.66"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.66.tgz#623de62c638a31cda5d44014b981290e3f79f6de"
   integrity sha512-lo8ZcAO/zL2pZWH+LZIyge8u2MklaeuT6+FpVVpBFktMVdYXbaVtzpvWbgRFBZHvL3SRDF+u8jxjtkXhvGUpTw==
 
+"@swc/core-linux-x64-musl@1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.67.tgz#fbb63517cd72eaa3250726a4209c179ada520a57"
+  integrity sha512-ED0H6oLvQmhgo9zs8usmEA/lcZPGTu7K9og9K871b7HhHX0h/R+Xg2pb5KD7S/GyUHpfuopxjVROm+h6X1jMUA==
+
 "@swc/core-win32-arm64-msvc@1.3.66":
   version "1.3.66"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.66.tgz#49a432f43a314666e681a98801d7b2d303e5ef75"
   integrity sha512-cQoVwBuJY5WkHbfpCOlndNwYr1ZThatRjQQvKy540NUIeAEk9Fa6ozlDBtU75UdaWKtUG6YQ/bWz+KTemheVxw==
+
+"@swc/core-win32-arm64-msvc@1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.67.tgz#dadce08f9245c57e9c54c1bbcc815c4bd2077fba"
+  integrity sha512-J1yFDLgPFeRtA8t5E159OXX+ww1gbkFg70yr4OP7EsOkOD1uMkuTf9yK/woHfsaVJlUYjJHzw7MkUIEgQBucqQ==
 
 "@swc/core-win32-ia32-msvc@1.3.66":
   version "1.3.66"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.66.tgz#80c8af627b46de67fbac05908025e764194669ad"
   integrity sha512-y/FrAIINK4UBeUQQknGlWXEyjo+MBvjF7WkUf2KP7sNr9EHHy8+dXohAGd5Anz0eJrqOM1ZXR/GEjxRp7bGQ1Q==
 
+"@swc/core-win32-ia32-msvc@1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.67.tgz#be026a3a389e64c24fe67a329c04eccf744ac45e"
+  integrity sha512-bK11/KtasewqHxzkjKUBXRE9MSAidbZCxrgJUd49bItG2N/DHxkwMYu8Xkh5VDHdTYWv/2idYtf/VM9Yi+53qw==
+
 "@swc/core-win32-x64-msvc@1.3.66":
   version "1.3.66"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.66.tgz#7984da6bf1f1a5410c2e6514dc2814abb2e6c91a"
   integrity sha512-yI64ACzS14qFLrfyO12qW+f/UROTotzDeEbuyJAaPD2IZexoT1cICznI3sBmIfrSt33mVuW8eF5m3AG/NUImzw==
+
+"@swc/core-win32-x64-msvc@1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.67.tgz#6fe2f3854d91b58f6e0b00f99366cfd84334b2ea"
+  integrity sha512-GxzUU3+NA3cPcYxCxtfSQIS2ySD7Z8IZmKTVaWA9GOUQbKLyCE8H5js31u39+0op/1gNgxOgYFDoj2lUyvLCqw==
 
 "@swc/core@^1.3.66":
   version "1.3.66"
@@ -2194,6 +2244,22 @@
     "@swc/core-win32-arm64-msvc" "1.3.66"
     "@swc/core-win32-ia32-msvc" "1.3.66"
     "@swc/core-win32-x64-msvc" "1.3.66"
+
+"@swc/core@^1.3.67":
+  version "1.3.67"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.67.tgz#e0eb33285abb07cb0fd097d4190096977971da1e"
+  integrity sha512-9DROjzfAEt0xt0CDkOYsWpkUPyne8fl5ggWGon049678BOM7p0R0dmaalZGAsKatG5vYP1IWSKWsKhJIubDCsQ==
+  optionalDependencies:
+    "@swc/core-darwin-arm64" "1.3.67"
+    "@swc/core-darwin-x64" "1.3.67"
+    "@swc/core-linux-arm-gnueabihf" "1.3.67"
+    "@swc/core-linux-arm64-gnu" "1.3.67"
+    "@swc/core-linux-arm64-musl" "1.3.67"
+    "@swc/core-linux-x64-gnu" "1.3.67"
+    "@swc/core-linux-x64-musl" "1.3.67"
+    "@swc/core-win32-arm64-msvc" "1.3.67"
+    "@swc/core-win32-ia32-msvc" "1.3.67"
+    "@swc/core-win32-x64-msvc" "1.3.67"
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -2695,6 +2761,11 @@ ansi-align@^3.0.0:
   dependencies:
     string-width "^4.1.0"
 
+ansi-colors@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+
 ansi-colors@^4.1.1, ansi-colors@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
@@ -3123,6 +3194,11 @@ brotli-size@4.0.0:
   dependencies:
     duplexer "0.1.1"
 
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+  integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
 browserslist@^4.21.3, browserslist@^4.21.5:
   version "4.21.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.5.tgz#75c5dae60063ee641f977e00edd3cfb2fb7af6a7"
@@ -3220,7 +3296,7 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.2.0:
+camelcase@^6.0.0, camelcase@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -3272,12 +3348,12 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-checksync@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/checksync/-/checksync-4.0.0.tgz#fd74959cc91f665047ae94b541ab22007b0a9b53"
-  integrity sha512-G+wpCe4LfFLUSLCD+cSwF/stWXP9tm4M2Iy+8CBKiBX0izZ53nHTzbQ02aKfVxg6Q87e1xd/Q7AJbPXqiQxacw==
+checksync@^5.0.0:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/checksync/-/checksync-5.0.4.tgz#6d69c4750e9c83c05284fd4a183ad72145f89542"
+  integrity sha512-7g7WRqMY/pPQFzG41ovh+yez7HLuL1cXYWMHWK02PiHwWC7GOiQ6eUaCIvXfmQ2mHYSuDurvhrqse6DEl9/+hw==
 
-chokidar@^3.4.3:
+chokidar@3.5.3, chokidar@^3.4.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -3597,7 +3673,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -3623,6 +3699,11 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
+
+decamelize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
+  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
 decimal.js@^10.4.3:
   version "10.4.3"
@@ -3731,6 +3812,11 @@ diff-sequences@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
   integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
+
+diff@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 dir-glob@^2.0.0:
   version "2.2.2"
@@ -3994,6 +4080,11 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
+escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -4003,11 +4094,6 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
-
-escape-string-regexp@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
-  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@^1.13.0:
   version "1.14.3"
@@ -4552,20 +4638,20 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+find-up@5.0.0, find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
-    path-exists "^4.0.0"
-
-find-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
     path-exists "^4.0.0"
 
 find-yarn-workspace-root2@1.2.16:
@@ -4588,6 +4674,11 @@ flat-cache@^3.0.4:
   dependencies:
     flatted "^3.1.0"
     rimraf "^3.0.2"
+
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 flatted@^3.1.0:
   version "3.2.7"
@@ -4850,6 +4941,18 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
@@ -5124,6 +5227,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 heapdump@^0.3.15:
   version "0.3.15"
@@ -5477,6 +5585,11 @@ is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
+
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-plain-obj@^3.0.0:
   version "3.0.0"
@@ -6023,6 +6136,13 @@ jest@^29.5.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-yaml@4.1.0, js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.6.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
@@ -6030,13 +6150,6 @@ js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.6.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
 
 js2xmlparser@^4.0.2:
   version "4.0.2"
@@ -6350,7 +6463,7 @@ log-driver@^1.2.7:
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
   integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
-log-symbols@^4.1.0:
+log-symbols@4.1.0, log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
@@ -6625,6 +6738,13 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+minimatch@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -6749,6 +6869,33 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mocha@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
+  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
+  dependencies:
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.5.3"
+    debug "4.3.4"
+    diff "5.0.0"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.2.0"
+    he "1.2.0"
+    js-yaml "4.1.0"
+    log-symbols "4.1.0"
+    minimatch "5.0.1"
+    ms "2.1.3"
+    nanoid "3.3.3"
+    serialize-javascript "6.0.0"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
+    workerpool "6.2.1"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
+
 module-details-from-path@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
@@ -6789,6 +6936,11 @@ nan@^2.13.2, nan@^2.14.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
+
+nanoid@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -8042,6 +8194,13 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
+serialize-javascript@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
+  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
+  dependencies:
+    randombytes "^2.1.0"
+
 serialize-javascript@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
@@ -8432,7 +8591,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -8459,6 +8618,13 @@ superagent@^5.3.1:
     readable-stream "^3.6.0"
     semver "^7.3.2"
 
+supports-color@8.1.1, supports-color@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -8470,13 +8636,6 @@ supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
-supports-color@^8.0.0:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -9110,6 +9269,11 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
+workerpool@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
+  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
+
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
@@ -9186,6 +9350,11 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yargs-parser@20.2.4:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+
 yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
@@ -9204,6 +9373,29 @@ yargs-parser@^21.1.1:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
+yargs-unparser@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
+  integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
+  dependencies:
+    camelcase "^6.0.0"
+    decamelize "^4.0.0"
+    flat "^5.0.2"
+    is-plain-obj "^2.1.0"
+
+yargs@16.2.0, yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
 yargs@^15.1.0:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
@@ -9220,19 +9412,6 @@ yargs@^15.1.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
-
-yargs@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^20.2.2"
 
 yargs@^17.1.1, yargs@^17.3.1:
   version "17.7.1"


### PR DESCRIPTION
## Summary:
We want to be able to run eslint both before and after migration without having to change the version of eslint itself.  This will simplify the migration, but it means we need those old eslint rules that I deleted back in #692.  This PR adds them back.

I needed to tweak the mocha configuration to process the files with 'swc' so that it can load src/index.ts.

Issue: None

## Test plan:
- cd packages/eslint-config-khan
- yarn install
- yarn test