### PR TITLE
[fei5245.1.wsbuildsettings] Change build settings package to be in Khan namespace

### DIFF
--- a/.changeset/red-fishes-thank.md
+++ b/.changeset/red-fishes-thank.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/ws-dev-build-settings": major
+---
+
+Moved build settings to Khan Academy namespace

--- a/build-settings/package.json
+++ b/build-settings/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "ws-dev-build-settings",
+    "name": "@khanacademy/ws-dev-build-settings",
     "version": "1.2.0",
     "license": "MIT",
     "private": true

--- a/packages/wonder-stuff-ci/package.json
+++ b/packages/wonder-stuff-ci/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "@types/node": "^20.4.2",
-        "ws-dev-build-settings": "^1.2.0"
+        "@khanacademy/ws-dev-build-settings": "^1.2.0"
     },
     "author": "",
     "license": "MIT",

--- a/packages/wonder-stuff-core/package.json
+++ b/packages/wonder-stuff-core/package.json
@@ -20,7 +20,7 @@
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },
     "devDependencies": {
-        "ws-dev-build-settings": "^1.2.0"
+        "@khanacademy/ws-dev-build-settings": "^1.2.0"
     },
     "browser": {
         "dist/es/index.js": "./dist/browser/es/index.js",

--- a/packages/wonder-stuff-i18n/package.json
+++ b/packages/wonder-stuff-i18n/package.json
@@ -26,7 +26,7 @@
         "pofile": "^1.1.4"
     },
     "devDependencies": {
-        "ws-dev-build-settings": "^1.2.0"
+        "@khanacademy/ws-dev-build-settings": "^1.2.0"
     },
     "bin": {
         "all-i18n-strings": "./dist/bin/all-i18n-strings.js",

--- a/packages/wonder-stuff-render-environment-jsdom/package.json
+++ b/packages/wonder-stuff-render-environment-jsdom/package.json
@@ -26,7 +26,7 @@
         "@khanacademy/wonder-stuff-render-server": "^1.0.7"
     },
     "devDependencies": {
-        "ws-dev-build-settings": "^1.2.0"
+        "@khanacademy/ws-dev-build-settings": "^1.2.0"
     },
     "peerDependencies": {
         "jsdom": "^21.1.1"

--- a/packages/wonder-stuff-render-server/package.json
+++ b/packages/wonder-stuff-render-server/package.json
@@ -25,7 +25,7 @@
         "@khanacademy/wonder-stuff-server": "^5.0.0"
     },
     "devDependencies": {
-        "ws-dev-build-settings": "^1.2.0"
+        "@khanacademy/ws-dev-build-settings": "^1.2.0"
     },
     "peerDependencies": {
         "@google-cloud/kms": "^3.4.0",

--- a/packages/wonder-stuff-sentry/package.json
+++ b/packages/wonder-stuff-sentry/package.json
@@ -23,7 +23,7 @@
         "@khanacademy/wonder-stuff-core": "^1.5.1"
     },
     "devDependencies": {
-        "ws-dev-build-settings": "^1.2.0"
+        "@khanacademy/ws-dev-build-settings": "^1.2.0"
     },
     "browser": {
         "dist/es/index.js": "./dist/browser/es/index.js",

--- a/packages/wonder-stuff-server/package.json
+++ b/packages/wonder-stuff-server/package.json
@@ -23,7 +23,7 @@
         "@khanacademy/wonder-stuff-core": "^1.5.1"
     },
     "devDependencies": {
-        "ws-dev-build-settings": "^1.2.0"
+        "@khanacademy/ws-dev-build-settings": "^1.2.0"
     },
     "author": "",
     "license": "MIT",

--- a/packages/wonder-stuff-testing/package.json
+++ b/packages/wonder-stuff-testing/package.json
@@ -23,7 +23,7 @@
         "@khanacademy/wonder-stuff-core": "^1.5.1"
     },
     "devDependencies": {
-        "ws-dev-build-settings": "^1.2.0"
+        "@khanacademy/ws-dev-build-settings": "^1.2.0"
     },
     "browser": {
         "dist/es/index.js": "./dist/browser/es/index.js",


### PR DESCRIPTION
## Summary:
This renames the build settings package so that it is namespaced to Khan Academy. This ensures that someone cannot squat the package in NPM as they would need to be able to publish to the Khan Academy NPM org.

Issue: FEI-5245

## Test plan:
Not much to test here, but I did test that the package still builds.