### PR TITLE
Add moar helper types to wonder-stuff-core

### DIFF
--- a/.changeset/violet-cherries-clean.md
+++ b/.changeset/violet-cherries-clean.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-core": minor
+---
+
+Add Without, Nullable, and TSFixMe helper types

--- a/packages/wonder-stuff-core/src/types.ts
+++ b/packages/wonder-stuff-core/src/types.ts
@@ -37,3 +37,28 @@ export type Secrets = {readonly [key: string]: SecretString};
  * Make a read-only type mutable.
  */
 export type Mutable<T> = {-readonly [P in keyof T]: T[P]};
+
+/**
+ * Remove the keys in `R` from `C`.
+ */
+export type Without<C, R> = Omit<C, keyof R>;
+
+/**
+ * Opposite of `NonNullable<T>`.
+ *
+ * This type is most useful in making code that's been converted from Flow
+ * to TypeScript more readable.
+ */
+export type Nullable<T> = T | null | undefined;
+
+/**
+ * This type can be used in place of `any` to indicate that we don't know
+ * what the type is, but we know that it is wrong and needs to be fixed.
+ *
+ * It's similar to $FlowFixMe in Flow.
+ *
+ * This should be used in situations where `@ts-expect-error` cannot be used
+ * or should not be used (as is the case with type errors on props in JSX
+ * elements).
+ */
+export type TSFixMe<Message extends string = string> = Message & any;


### PR DESCRIPTION
## Summary:
A number of repos are defining the same or similar utility types.  Let's bring them into wonder-stuff-core so that they're consistent across projects.

## Test Plan:
N/A