### PR TITLE
[fixusageoutsidejest] Allow import outside of jest

### DIFF
--- a/.changeset/chatty-cobras-roll.md
+++ b/.changeset/chatty-cobras-roll.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-stuff-testing": patch
+---
+
+Allow Wonder Stuff Testing to be imported outside of jest

--- a/packages/wonder-stuff-testing/src/jest/wait.ts
+++ b/packages/wonder-stuff-testing/src/jest/wait.ts
@@ -1,8 +1,5 @@
 import {verifyRealTimers} from "./internal/verify-real-timers";
 import {unverifiedWait} from "./internal/unverified-wait";
-import {assertJest} from "./internal/assert-jest";
-
-assertJest();
 
 type WaitOptions = {
     /**


### PR DESCRIPTION
## Summary:
The `wait` function copied from Webapp verified that jest was in use at import. This worked when in webapp and it was just a file being imported, but now it's in Wonder Stuff Testing, it causes an error if any of the non-jest code is used outside of a jest environment, which is not what we want at all.

So, this removes that module level check, which in turn means Wonder Stuff Testing can be used in non-jest contexts, like stories.

See [Slack thread](https://khanacademy.slack.com/archives/CEA6W0F6F/p1707955461083099?thread_ts=1707867450.595019&cid=CEA6W0F6F) for more context, if you have access.

Issue: XXX-XXXX

## Test plan:
`yarn test`

Once published, we can update webapp and verify `dataFactoryFor` is usable within stories.