### PR TITLE
[fei5815.1.excludebuildinfo] Add .npmignore file

### DIFF
--- a/.changeset/six-chefs-doubt.md
+++ b/.changeset/six-chefs-doubt.md
@@ -1,0 +1,12 @@
+---
+"@khanacademy/wonder-stuff-ci": patch
+"@khanacademy/wonder-stuff-core": patch
+"@khanacademy/wonder-stuff-i18n": patch
+"@khanacademy/wonder-stuff-render-environment-jsdom": patch
+"@khanacademy/wonder-stuff-render-server": patch
+"@khanacademy/wonder-stuff-sentry": patch
+"@khanacademy/wonder-stuff-server": patch
+"@khanacademy/wonder-stuff-testing": patch
+---
+
+Don't include TypeScript config and buildinfo in packages

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+*.tsbuildinfo
+tsconfig-build.json


### PR DESCRIPTION
## Summary:
This adds an `.npmignore` file to the project to exclude unnecessary files from the published package. Any `files` declaration in a `package.json` will override this, so that's something to watch out for, but this is sufficient for now.

Issue: FEI-5815

## Test plan:
1. `yarn`
2. `yarn build`
3. `yarn build:types`
4. `rm .npmignore`
5. `cd packages/wonder-stuff-server`
6. `npm pack --dry-run`
7. Observe that the `tsconfig-build.json` and `tsconfig-build.tsbuildinfo` are included
8. `cd ../..`
9. `git checkout .npmignore`
10. `cd packages/wonder-stuff-server`
11. `npm pack --dry-run`
12. Observe that the `tsconfig-build.json` and `tsconfig-build.tsbuildinfo` are not included