### PR TITLE
Update error message for aphrodite-add-style-variable-name rule

### DIFF
--- a/.changeset/perfect-cycles-fry.md
+++ b/.changeset/perfect-cycles-fry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-plugin": patch
+---
+
+Update error message for `aphrodite-add-style-variable-name` rule

--- a/packages/eslint-plugin-khan/src/rules/aphrodite-add-style-variable-name.ts
+++ b/packages/eslint-plugin-khan/src/rules/aphrodite-add-style-variable-name.ts
@@ -10,7 +10,7 @@ const createRule = ESLintUtils.RuleCreator<MyPluginDocs>(
 type Options = [];
 type MessageIds = "errorString";
 
-const message = `Variable name "{{ variableName }}" does not match tag name "{{ tagName }}". Variable name should be "{{ expectedName }}"`;
+const message = `Variable name "{{ variableName }}" does not match the expected naming convention. Expected: "{{ expectedName }}"`;
 
 /**
  * Converts a string into PascalCase.

--- a/packages/eslint-plugin-khan/src/rules/aphrodite-add-style-variable-name.ts
+++ b/packages/eslint-plugin-khan/src/rules/aphrodite-add-style-variable-name.ts
@@ -99,7 +99,6 @@ export default createRule<Options, MessageIds>({
                         messageId: "errorString",
                         data: {
                             variableName,
-                            tagName,
                             expectedName,
                         },
                     });

--- a/packages/eslint-plugin-khan/test/rules/aphrodite-add-style-variable-name.test.ts
+++ b/packages/eslint-plugin-khan/test/rules/aphrodite-add-style-variable-name.test.ts
@@ -80,7 +80,6 @@ ruleTester.run(ruleName, rule, {
                     messageId: "errorString",
                     data: {
                         variableName: "foo",
-                        tagName: "div",
                         expectedName: "StyledDiv",
                     },
                 },
@@ -93,7 +92,6 @@ ruleTester.run(ruleName, rule, {
                     messageId: "errorString",
                     data: {
                         variableName: "div",
-                        tagName: "div",
                         expectedName: "StyledDiv",
                     },
                 },
@@ -106,7 +104,6 @@ ruleTester.run(ruleName, rule, {
                     messageId: "errorString",
                     data: {
                         variableName: "span",
-                        tagName: "span",
                         expectedName: "StyledSpan",
                     },
                 },
@@ -119,7 +116,6 @@ ruleTester.run(ruleName, rule, {
                     messageId: "errorString",
                     data: {
                         variableName: "p",
-                        tagName: "p",
                         expectedName: "StyledP",
                     },
                 },
@@ -132,7 +128,6 @@ ruleTester.run(ruleName, rule, {
                     messageId: "errorString",
                     data: {
                         variableName: "styledDiv",
-                        tagName: "div",
                         expectedName: "StyledDiv",
                     },
                 },
@@ -145,7 +140,6 @@ ruleTester.run(ruleName, rule, {
                     messageId: "errorString",
                     data: {
                         variableName: "FooBar",
-                        tagName: "foo-bar",
                         expectedName: "StyledFooBar",
                     },
                 },
@@ -158,7 +152,6 @@ ruleTester.run(ruleName, rule, {
                     messageId: "errorString",
                     data: {
                         variableName: "FooBar",
-                        tagName: "foo_bar",
                         expectedName: "StyledFooBar",
                     },
                 },
@@ -171,7 +164,6 @@ ruleTester.run(ruleName, rule, {
                     messageId: "errorString",
                     data: {
                         variableName: "FooBar",
-                        tagName: "FooBar",
                         expectedName: "StyledFooBar",
                     },
                 },


### PR DESCRIPTION
## Summary:
Updating the error message so it is more useful (noticed this after testing with the demo project)

Previously: `Variable name "div" does not match tag name "div". Variable name should be "StyledDiv"`

<img width="1203" alt="Screenshot 2024-12-13 at 2 26 27 PM" src="https://github.com/user-attachments/assets/1d3fd862-461f-4afd-b4bf-10c4ae7368be" />



New: `Variable name "div" does not match the expected naming convention. Expected: "StyledDiv"` 

Issue: FEI-5952

## Test plan:
- Tests continue to pass
- Will integrate with the demo project once this update is released!