### PR TITLE
Mark demo project as non-publishable

### DIFF
--- a/.changeset/happy-dots-bake.md
+++ b/.changeset/happy-dots-bake.md
@@ -1,0 +1,5 @@
+---
+"demo": patch
+---
+
+Mark demo project as private

--- a/packages/eslint-plugin-khan/demo/package.json
+++ b/packages/eslint-plugin-khan/demo/package.json
@@ -2,6 +2,7 @@
   "name": "demo",
   "version": "0.0.2",
   "main": "index.js",
+  "private": true,
   "license": "MIT",
   "scripts": {
     "lint": "eslint --ext .ts --ext .js --ext .tsx --ext .jsx ."


### PR DESCRIPTION
## Summary:

The most recent release failed near the end because it tried to publish the `demo` project. This PR changes the demo project to be explicitly private. This will help changesets know not to try to publish it. 

This didn't happen in the demo project in earlier releases because it wasn't in the Yarn workspace. With pnpm, we can add it to the workspace, but that caused changesets to try to publish it.  By marking it as `private: true`, we'll block that in the future. 

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/f2f38370-f349-47dd-b713-e4605a3405ec" />

Issue: FEI-6300

## Test plan:

We'll need to land this and then release the Version Packages PR that's created by it.